### PR TITLE
docs: add Terraform Registry badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Terraform provider for Nagios XI
 
 [![test](https://github.com/dunkin0486/terraform-provider-nagios/actions/workflows/test.yml/badge.svg)](https://github.com/dunkin0486/terraform-provider-nagios/actions/workflows/test.yml)
+[![Terraform Registry](https://img.shields.io/badge/terraform--registry-dunkin0486%2Fnagios-844FBA?logo=terraform)](https://registry.terraform.io/providers/dunkin0486/nagios/latest)
 
 ## Supported Nagios XI versions
 


### PR DESCRIPTION
## Summary
- Adds a Terraform Registry badge to the README, linking to https://registry.terraform.io/providers/dunkin0486/nagios/latest now that v2.0.1 is published.

Closes out #92.