### PR TITLE
fix: run test workflow once per PR instead of twice

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: test
 on:
   push:
     branches:
-      - '**'
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary
- Narrows `test.yml`'s `push` trigger from `branches: ['**']` to `branches: [main]`.

Every PR from a feature branch currently gets two `test` check runs against the same commit - one from `push` (any branch matched `**`) and one from `pull_request`. This keeps exactly the coverage that's needed: `pull_request` still covers every PR regardless of branch (what branch protection's required check actually needs), and `push: [main]` still covers direct pushes/post-merge commits on main (keeps the README test badge meaningful independent of any PR).

Closes #101

## Testing
- [x] Workflow YAML change only, no code touched
- [ ] Confirm on this PR itself: only one `test` check should appear below, not two