### PR TITLE
feat: add parents field to nagios_host

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,19 @@ TF_ACC=1 go test -v -count=1 ./internal/provider/... -run TestAccHostBasic    # 
 
 The container reports itself `healthy` once installed; `docker compose ps` from `test/docker/nagiosxi/` confirms this. See `test/docker/nagiosxi/README.md` for the installer quirks that were worked around to get it booting (Rocky Linux OS-detection, php-fpm ACL support, etc.) — that layer is unrelated to the provider code itself.
 
+### Test-driven development
+
+New `internal/client`/`internal/provider` behavior is written test-first, not implementation-first. This is how the original framework rewrite was done (see the closed "Phase 3: TDD rewrite - ..." issues, #74-81) and it's the expected workflow for new work, not just historical practice.
+
+For a new field/resource/data source:
+
+1. Write the acceptance test (or unit test, for pure `internal/client` logic) first, asserting the behavior you want.
+2. Run it against the live Docker instance and confirm it fails for the expected reason (missing schema attribute, unset field, etc.) — a red test that fails for the wrong reason (a typo, a config error) proves nothing.
+3. Implement the minimum change to make it pass.
+4. Run the full acceptance suite before opening the PR, per the rule above.
+
+Skipping straight to implementation and writing tests afterward is a common shortcut to avoid — it's easy to end up with tests that just confirm what the code already does rather than what it's supposed to do.
+
 ### Docs
 
 ```bash

--- a/docs/data-sources/host.md
+++ b/docs/data-sources/host.md
@@ -63,6 +63,7 @@ output "web01_address" {
 - `notification_period` (String)
 - `notifications_enabled` (Boolean)
 - `obsess_over_host` (Boolean)
+- `parents` (Set of String)
 - `passive_checks_enabled` (Boolean)
 - `process_perf_data` (Boolean)
 - `register` (Boolean)

--- a/docs/resources/host.md
+++ b/docs/resources/host.md
@@ -74,6 +74,7 @@ resource "nagios_host" "example" {
 - `notification_options` (String) Determines when Nagios should alert if a host is one or more of the following option: 'o' up, 'd' down, 'u' unreachable, 'r' recovery, 'f' flapping or 's' scheduled downtime
 - `notifications_enabled` (Boolean) Determines if Nagios should send notifications
 - `obsess_over_host` (Boolean) Sets whether or not Nagios 'obsesses' over the host using the ochp_command
+- `parents` (Set of String) A list of hosts that are used to determine the network reachability of this host - if a parent host is down or unreachable, this host is marked unreachable rather than down
 - `passive_checks_enabled` (Boolean) Sets whether or not passive checks are enabled for the host
 - `process_perf_data` (Boolean) Determines if Nagios should process performance data
 - `register` (Boolean) Determines if the host will be marked as active or inactive

--- a/internal/client/host.go
+++ b/internal/client/host.go
@@ -21,6 +21,7 @@ type Host struct {
 	Templates                  []string          `json:"use,omitempty"`
 	CheckCommand               string            `json:"check_command,omitempty"`
 	ContactGroups              []string          `json:"contact_groups,omitempty"`
+	Parents                    []string          `json:"parents,omitempty"`
 	Notes                      string            `json:"notes,omitempty"`
 	NotesURL                   string            `json:"notes_url,omitempty"`
 	ActionURL                  string            `json:"action_url,omitempty"`

--- a/internal/provider/data_source_host.go
+++ b/internal/provider/data_source_host.go
@@ -47,6 +47,7 @@ func (d *hostDataSource) Schema(ctx context.Context, req datasource.SchemaReques
 			"templates":                    schema.SetAttribute{Computed: true, ElementType: types.StringType},
 			"check_command":                schema.StringAttribute{Computed: true},
 			"contact_groups":               schema.SetAttribute{Computed: true, ElementType: types.StringType},
+			"parents":                      schema.SetAttribute{Computed: true, ElementType: types.StringType},
 			"notes":                        schema.StringAttribute{Computed: true},
 			"notes_url":                    schema.StringAttribute{Computed: true},
 			"action_url":                   schema.StringAttribute{Computed: true},

--- a/internal/provider/resource_host.go
+++ b/internal/provider/resource_host.go
@@ -45,6 +45,7 @@ type hostModel struct {
 	Templates                  types.Set    `tfsdk:"templates"`
 	CheckCommand               types.String `tfsdk:"check_command"`
 	ContactGroups              types.Set    `tfsdk:"contact_groups"`
+	Parents                    types.Set    `tfsdk:"parents"`
 	Notes                      types.String `tfsdk:"notes"`
 	NotesURL                   types.String `tfsdk:"notes_url"`
 	ActionURL                  types.String `tfsdk:"action_url"`
@@ -140,6 +141,11 @@ func (r *hostResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Optional:    true,
 				ElementType: types.StringType,
 				Description: "A list of the contact groups that should be notified if the host goes down",
+			},
+			"parents": schema.SetAttribute{
+				Optional:    true,
+				ElementType: types.StringType,
+				Description: "A list of hosts that are used to determine the network reachability of this host - if a parent host is down or unreachable, this host is marked unreachable rather than down",
 			},
 			"notes": schema.StringAttribute{
 				Optional:    true,
@@ -423,6 +429,8 @@ func hostFromModel(ctx context.Context, m *hostModel) (*client.Host, diag.Diagno
 	diags.Append(d...)
 	contactGroups, d := setToStrings(ctx, m.ContactGroups)
 	diags.Append(d...)
+	parents, d := setToStrings(ctx, m.Parents)
+	diags.Append(d...)
 	flapDetectionOptions, d := setToStrings(ctx, m.FlapDetectionOptions)
 	diags.Append(d...)
 	freeVariables, d := mapToStrings(ctx, m.FreeVariables)
@@ -445,6 +453,7 @@ func hostFromModel(ctx context.Context, m *hostModel) (*client.Host, diag.Diagno
 		Templates:                  templates,
 		CheckCommand:               m.CheckCommand.ValueString(),
 		ContactGroups:              contactGroups,
+		Parents:                    parents,
 		Notes:                      m.Notes.ValueString(),
 		NotesURL:                   m.NotesURL.ValueString(),
 		ActionURL:                  m.ActionURL.ValueString(),
@@ -507,6 +516,10 @@ func modelFromHost(ctx context.Context, m *hostModel, h *client.Host) diag.Diagn
 	contactGroups, d := stringsToSet(ctx, h.ContactGroups)
 	diags.Append(d...)
 	m.ContactGroups = contactGroups
+
+	parents, d := stringsToSet(ctx, h.Parents)
+	diags.Append(d...)
+	m.Parents = parents
 
 	m.Notes = stringOrNull(h.Notes)
 	m.NotesURL = stringOrNull(h.NotesURL)

--- a/internal/provider/resource_host_test.go
+++ b/internal/provider/resource_host_test.go
@@ -88,6 +88,86 @@ func TestAccHostUpdateName(t *testing.T) {
 	})
 }
 
+func TestAccHostParents(t *testing.T) {
+	firstParentName := "tf_" + acctest.RandString(10)
+	secondParentName := "tf_" + acctest.RandString(10)
+	childName := "tf_" + acctest.RandString(10)
+	rName := "nagios_host.child"
+	dataSourceName := "data.nagios_host.child_read"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckHostDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHostResourceWithParents(firstParentName, secondParentName, childName, firstParentName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHostExists(t, rName),
+					resource.TestCheckResourceAttr(rName, "parents.#", "1"),
+					resource.TestCheckTypeSetElemAttr(rName, "parents.*", firstParentName),
+					resource.TestCheckResourceAttrPair(dataSourceName, "parents", rName, "parents"),
+				),
+			},
+			{
+				// Update: swap to the other parent host, confirming the
+				// change is applied rather than just accepted at create.
+				Config: testAccHostResourceWithParents(firstParentName, secondParentName, childName, secondParentName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHostExists(t, rName),
+					resource.TestCheckResourceAttr(rName, "parents.#", "1"),
+					resource.TestCheckTypeSetElemAttr(rName, "parents.*", secondParentName),
+					resource.TestCheckResourceAttrPair(dataSourceName, "parents", rName, "parents"),
+				),
+			},
+		},
+	})
+}
+
+func testAccHostResourceWithParents(firstParentName, secondParentName, childName, activeParentName string) string {
+	return fmt.Sprintf(`
+resource "nagios_host" "parent1" {
+	host_name              = %[1]q
+	address                = "127.0.0.1"
+	max_check_attempts     = "5"
+	check_period            = "24x7"
+	notification_interval   = "10"
+	notification_period     = "24x7"
+	contacts                = ["nagiosadmin"]
+	templates                = ["generic-host"]
+}
+
+resource "nagios_host" "parent2" {
+	host_name              = %[2]q
+	address                = "127.0.0.1"
+	max_check_attempts     = "5"
+	check_period            = "24x7"
+	notification_interval   = "10"
+	notification_period     = "24x7"
+	contacts                = ["nagiosadmin"]
+	templates                = ["generic-host"]
+}
+
+resource "nagios_host" "child" {
+	host_name              = %[3]q
+	address                = "127.0.0.2"
+	max_check_attempts     = "5"
+	check_period            = "24x7"
+	notification_interval   = "10"
+	notification_period     = "24x7"
+	contacts                = ["nagiosadmin"]
+	templates                = ["generic-host"]
+	parents                  = [%[4]q]
+
+	depends_on = [nagios_host.parent1, nagios_host.parent2]
+}
+
+data "nagios_host" "child_read" {
+	host_name = nagios_host.child.host_name
+}
+`, firstParentName, secondParentName, childName, activeParentName)
+}
+
 func testAccHostResourceBasic(name, alias, address, maxCheckAttempts, checkPeriod, notificationInterval, notificationPeriod, contacts, templates string) string {
 	return fmt.Sprintf(`
 resource "nagios_host" "host" {


### PR DESCRIPTION
## Summary

- Adds `parents` to the `nagios_host` resource and data source - network reachability dependencies (if a parent host is down/unreachable, this host is marked unreachable rather than down). Found during the #93 release-notes survey, tracked as #105.
- Requires new `internal/client`/`internal/provider` work to be test-driven (CLAUDE.md) - write the test first, confirm it fails for the right reason against a live instance, then implement.

## Why `service.parents` isn't in this PR

It was implemented and tested alongside `host.parents`, exactly as #105 originally scoped. `TestAccServiceParents` failed: Terraform reported "provider produced inconsistent result after apply" because `parents` was accepted on write but never returned on read. Direct inspection of the live Nagios XI test instance's database confirmed why: `tbl_host` has a `parents` column, `tbl_service` has none. The API's write whitelist accepts `parents` for services (likely copy-pasted from the host handler), but there's nowhere to store it - it's silently dropped. Rather than ship a field that looks like it works but doesn't, it's been removed from scope entirely. Full details in #105's latest comment.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] `golangci-lint run ./...` (v2.12.2, matches CI) - 0 issues
- [x] `go test ./internal/client/...` - pass
- [x] `TF_ACC=1 go test ./internal/provider/...` (full suite, live Nagios XI 2026R1.6.1) - 21/21 pass, including new `TestAccHostParents`
- [x] `tfplugindocs generate` - `docs/resources/host.md`, `docs/data-sources/host.md` regenerated

Closes #105

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>