### PR TITLE
ci: auto-approve and auto-merge the release-please PR

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,6 +19,24 @@ jobs:
         with:
           release-type: go
 
+      # main requires 1 approving review before merge, and GitHub won't let
+      # a PR approve itself - release-please's PR is authored by
+      # github-actions[bot] via the default GITHUB_TOKEN, so that token can
+      # never approve it. RELEASE_PLEASE_PAT is a personal access token
+      # belonging to a human maintainer (not the bot), so it can approve a
+      # PR it didn't author. Bot-bypass branch protection isn't an option
+      # here - GitHub restricts bypass actors to organization-owned repos,
+      # confirmed via both the classic and ruleset APIs on this personal repo.
+      - name: approve and auto-merge the release PR
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_PAT }}
+          PR_JSON: ${{ steps.release.outputs.pr }}
+        run: |
+          PR_NUMBER=$(jq -r '.number' <<< "$PR_JSON")
+          gh pr review "$PR_NUMBER" --approve --body "Auto-approved: release-please version bump."
+          gh pr merge "$PR_NUMBER" --auto --squash
+
       # release-please pushes the tag/release using the default GITHUB_TOKEN,
       # which GitHub deliberately excludes from triggering other workflows
       # (avoids infinite trigger loops) - so release.yml's `on: push: tags`


### PR DESCRIPTION
## Summary

- release-please's version-bump PR required a manual merge on top of whatever PR actually shipped the change - two merges per release.
- main's branch protection requires 1 approving review, and GitHub won't let a PR approve itself, so the bot-authored release PR could never clear that on its own.
- Bot-bypass branch protection isn't available here - GitHub restricts bypass actors to organization-owned repos (confirmed via 422s from both the classic branch-protection and rulesets APIs on this personal-account repo).

## Change

`release-please.yml` now uses `RELEASE_PLEASE_PAT` (a maintainer PAT, already set as a repo secret, scoped to Pull requests: read/write on this repo only) to approve the release PR release-please opens, then enables GitHub's native auto-merge. The actual merge still only completes once the required `test` status check passes - this doesn't bypass CI, only the manual click.

Also enabled `allow_auto_merge` at the repo level (was off, required for `gh pr merge --auto` to work at all).

## Test plan

Can't fully dry-run this without a real release-please PR, but each piece is independently verified:
- [x] `allow_auto_merge` confirmed `true` via `gh api repos/.../  --jq .allow_auto_merge`
- [x] `RELEASE_PLEASE_PAT` confirmed present via `gh secret list`
- [x] Workflow YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] `PR_JSON` passed via `env:` rather than spliced into the `run:` script, to avoid command injection from PR title/body text
- [ ] Real-world verification happens on the next release-please PR after this merges

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>