### PR TITLE
fix: give gh a repo context in the release-please auto-merge step

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,10 +27,15 @@ jobs:
       # PR it didn't author. Bot-bypass branch protection isn't an option
       # here - GitHub restricts bypass actors to organization-owned repos,
       # confirmed via both the classic and ruleset APIs on this personal repo.
+      # gh infers the target repo from the local git remote when --repo isn't
+      # given, and this job never checks the repo out - there's no .git dir
+      # for it to look at. Pass --repo explicitly instead of adding a
+      # checkout step that nothing else here needs.
       - name: approve and auto-merge the release PR
         if: ${{ steps.release.outputs.prs_created == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_PAT }}
+          GH_REPO: ${{ github.repository }}
           PR_JSON: ${{ steps.release.outputs.pr }}
         run: |
           PR_NUMBER=$(jq -r '.number' <<< "$PR_JSON")


### PR DESCRIPTION
PR #113 didn't auto-merge - the approve/merge step failed outright with "fatal: not a git repository". The release-please job never runs actions/checkout (release-please-action talks to the GitHub API directly, no working tree needed), so gh had no local git remote to infer the target repo from. Set GH_REPO explicitly instead of adding an unnecessary checkout step.

## Summary

<!-- What does this PR change, and why? -->

## Type of change

- [ ] Bug fix
- [ ] New resource / data source
- [ ] New attribute on an existing resource / data source
- [ ] Behavior change to an existing resource / data source (call this out explicitly below - this provider talks to a real external API with some real quirks, so anything that looks like a "fix" may be intentional; see CLAUDE.md)
- [ ] Docs / examples only
- [ ] Internal / tooling (CI, dependencies, refactor with no behavior change)

## Testing

- [ ] `go build ./...` and `go vet ./...` pass
- [ ] `go test ./internal/client/...` passes
- [ ] Acceptance tests pass against a live Nagios XI instance (`TF_ACC=1 go test -v -count=1 ./internal/provider/...` - see CONTRIBUTING.md for the Docker setup)
  - [ ] New/changed resources or data sources have `TestAcc*Basic` / `*CreateAfterManualDestroy` / `*UpdateName` coverage following the existing pattern

## Docs

- [ ] Schema changes are reflected in `Description` fields, and `tfplugindocs generate` has been run (no hand-edited files under `docs/`)

## Related issues

<!-- e.g. Closes #123, relates to #86 -->
