### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported Versions
+
+Only the current major version receives security fixes. This provider is
+maintained by one person on a best-effort basis - there's no backport
+policy for older majors.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 2.x     | :white_check_mark: |
+| 1.x     | :x:                |
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue for a security vulnerability.** Use
+GitHub's private vulnerability reporting instead: go to the
+[Security tab](https://github.com/dunkin0486/terraform-provider-nagios/security/advisories/new)
+and click "Report a vulnerability". This opens a private draft advisory
+that only you and the maintainer can see until it's resolved.
+
+This is a solo-maintained project, so there's no formal SLA - expect an
+initial response within a few days, not hours. If the report is accepted,
+I'll work with you on a fix and coordinate disclosure timing before
+publishing the advisory. If it's declined (not reproducible, out of
+scope, etc.), I'll explain why.
+
+In scope: vulnerabilities in this provider's own code (`internal/client`,
+`internal/provider`) or its release/build pipeline. Vulnerabilities in
+Nagios XI itself are out of scope - report those to
+[Nagios Enterprises](https://www.nagios.com/) directly.


### PR DESCRIPTION
Points reporters at GitHub's private vulnerability reporting (already enabled on this repo) instead of public issues, sets honest expectations for a solo-maintained project, and scopes reports to the provider itself rather than Nagios XI.

## Summary

<!-- What does this PR change, and why? -->

## Type of change

- [ ] Bug fix
- [ ] New resource / data source
- [ ] New attribute on an existing resource / data source
- [ ] Behavior change to an existing resource / data source (call this out explicitly below - this provider talks to a real external API with some real quirks, so anything that looks like a "fix" may be intentional; see CLAUDE.md)
- [ ] Docs / examples only
- [ ] Internal / tooling (CI, dependencies, refactor with no behavior change)

## Testing

- [ ] `go build ./...` and `go vet ./...` pass
- [ ] `go test ./internal/client/...` passes
- [ ] Acceptance tests pass against a live Nagios XI instance (`TF_ACC=1 go test -v -count=1 ./internal/provider/...` - see CONTRIBUTING.md for the Docker setup)
  - [ ] New/changed resources or data sources have `TestAcc*Basic` / `*CreateAfterManualDestroy` / `*UpdateName` coverage following the existing pattern

## Docs

- [ ] Schema changes are reflected in `Description` fields, and `tfplugindocs generate` has been run (no hand-edited files under `docs/`)

## Related issues

<!-- e.g. Closes #123, relates to #86 -->
