### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/dunkin0486/terraform-provider-nagios/security/code-scanning/1](https://github.com/dunkin0486/terraform-provider-nagios/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege access by default. For this workflow, `contents: read` is the best minimal setting and aligns with CodeQL guidance. This change does not alter functional behavior for normal CI read operations but hardens security by preventing unintended write scopes if defaults are permissive.

Edit **`.github/workflows/test.yml`** near the top-level keys:
- Insert:
  - `permissions:`
  - `  contents: read`
- Place it at root level (e.g., after `on:` and before `jobs:`) so it applies to the `test` job.

No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
