### PR TITLE
test: add unit tests for internal/provider's conversion functions

### DIFF
--- a/internal/provider/convert_test.go
+++ b/internal/provider/convert_test.go
@@ -1,0 +1,234 @@
+package provider
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestSetToStrings(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("null set becomes nil", func(t *testing.T) {
+		got, diags := setToStrings(ctx, types.SetNull(types.StringType))
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if got != nil {
+			t.Errorf("got %#v, want nil", got)
+		}
+	})
+
+	t.Run("unknown set becomes nil", func(t *testing.T) {
+		got, diags := setToStrings(ctx, types.SetUnknown(types.StringType))
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if got != nil {
+			t.Errorf("got %#v, want nil", got)
+		}
+	})
+
+	t.Run("populated set becomes matching slice", func(t *testing.T) {
+		set, diags := types.SetValueFrom(ctx, types.StringType, []string{"a", "b", "c"})
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics building fixture: %v", diags)
+		}
+
+		got, diags := setToStrings(ctx, set)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		sort.Strings(got)
+		want := []string{"a", "b", "c"}
+		if len(got) != len(want) {
+			t.Fatalf("got %#v, want %#v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("got %#v, want %#v", got, want)
+				break
+			}
+		}
+	})
+}
+
+func TestStringsToSet(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("nil slice becomes null set", func(t *testing.T) {
+		got, diags := stringsToSet(ctx, nil)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if !got.IsNull() {
+			t.Errorf("got %#v, want a null set", got)
+		}
+	})
+
+	t.Run("empty slice becomes null set", func(t *testing.T) {
+		got, diags := stringsToSet(ctx, []string{})
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if !got.IsNull() {
+			t.Errorf("got %#v, want a null set", got)
+		}
+	})
+
+	t.Run("populated slice becomes matching set", func(t *testing.T) {
+		got, diags := stringsToSet(ctx, []string{"x", "y"})
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+
+		var back []string
+		diags = got.ElementsAs(ctx, &back, false)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics reading back: %v", diags)
+		}
+		sort.Strings(back)
+		if len(back) != 2 || back[0] != "x" || back[1] != "y" {
+			t.Errorf("got %#v, want [x y]", back)
+		}
+	})
+}
+
+func TestMapToStrings(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("null map becomes nil", func(t *testing.T) {
+		got, diags := mapToStrings(ctx, types.MapNull(types.StringType))
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if got != nil {
+			t.Errorf("got %#v, want nil", got)
+		}
+	})
+
+	t.Run("unknown map becomes nil", func(t *testing.T) {
+		got, diags := mapToStrings(ctx, types.MapUnknown(types.StringType))
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if got != nil {
+			t.Errorf("got %#v, want nil", got)
+		}
+	})
+
+	t.Run("populated map becomes matching map", func(t *testing.T) {
+		m, diags := types.MapValueFrom(ctx, types.StringType, map[string]string{"_FOO": "bar"})
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics building fixture: %v", diags)
+		}
+
+		got, diags := mapToStrings(ctx, m)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if len(got) != 1 || got["_FOO"] != "bar" {
+			t.Errorf("got %#v, want map[_FOO:bar]", got)
+		}
+	})
+}
+
+func TestStringsMapToMap(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("nil map becomes null", func(t *testing.T) {
+		got, diags := stringsMapToMap(ctx, nil)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if !got.IsNull() {
+			t.Errorf("got %#v, want a null map", got)
+		}
+	})
+
+	t.Run("empty map becomes null", func(t *testing.T) {
+		got, diags := stringsMapToMap(ctx, map[string]string{})
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if !got.IsNull() {
+			t.Errorf("got %#v, want a null map", got)
+		}
+	})
+
+	t.Run("populated map round-trips", func(t *testing.T) {
+		got, diags := stringsMapToMap(ctx, map[string]string{"_SNMPCOMMUNITY": "public"})
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+
+		var back map[string]string
+		diags = got.ElementsAs(ctx, &back, false)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics reading back: %v", diags)
+		}
+		if len(back) != 1 || back["_SNMPCOMMUNITY"] != "public" {
+			t.Errorf("got %#v, want map[_SNMPCOMMUNITY:public]", back)
+		}
+	})
+}
+
+func TestStringOrNull(t *testing.T) {
+	if got := stringOrNull(""); !got.IsNull() {
+		t.Errorf("stringOrNull(\"\") = %#v, want null", got)
+	}
+	if got := stringOrNull("value"); got.ValueString() != "value" {
+		t.Errorf("stringOrNull(\"value\") = %#v, want \"value\"", got)
+	}
+}
+
+// TestOptionalBoolToNagios covers the historically-shipped bug this function
+// exists to fix: reading Go's bool zero-value for an unset optional silently
+// sent Nagios "0", indistinguishable from an explicit false. Null/unknown
+// must produce "" (omitted entirely), not "0".
+func TestOptionalBoolToNagios(t *testing.T) {
+	tests := []struct {
+		name string
+		in   types.Bool
+		want string
+	}{
+		{"null (unset) omits the field", types.BoolNull(), ""},
+		{"unknown omits the field", types.BoolUnknown(), ""},
+		{"explicit true", types.BoolValue(true), "1"},
+		{"explicit false", types.BoolValue(false), "0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := optionalBoolToNagios(tt.in); got != tt.want {
+				t.Errorf("optionalBoolToNagios(%#v) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNagiosToOptionalBool(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       string
+		wantNull bool
+		want     bool
+	}{
+		{"empty string (field not returned) becomes null", "", true, false},
+		{"1 becomes true", "1", false, true},
+		{"0 becomes false", "0", false, false},
+		{"anything else becomes false", "banana", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := nagiosToOptionalBool(tt.in)
+			if got.IsNull() != tt.wantNull {
+				t.Fatalf("nagiosToOptionalBool(%q).IsNull() = %v, want %v", tt.in, got.IsNull(), tt.wantNull)
+			}
+			if !tt.wantNull && got.ValueBool() != tt.want {
+				t.Errorf("nagiosToOptionalBool(%q) = %v, want %v", tt.in, got.ValueBool(), tt.want)
+			}
+		})
+	}
+}

--- a/internal/provider/resource_authserver_convert_test.go
+++ b/internal/provider/resource_authserver_convert_test.go
@@ -29,6 +29,15 @@ func TestAuthServerFromModel(t *testing.T) {
 	if a.LDAPHost != "ldap.example.com" {
 		t.Errorf("LDAPHost = %q, want ldap.example.com", a.LDAPHost)
 	}
+	if a.LDAPPort != "389" {
+		t.Errorf("LDAPPort = %q, want 389", a.LDAPPort)
+	}
+	if a.BaseDN != "DC=example,DC=com" {
+		t.Errorf("BaseDN = %q, want DC=example,DC=com", a.BaseDN)
+	}
+	if a.SecurityLevel != "tls" {
+		t.Errorf("SecurityLevel = %q, want tls", a.SecurityLevel)
+	}
 }
 
 func TestAuthServerFromModel_UnsetOptionalBool(t *testing.T) {
@@ -45,9 +54,11 @@ func TestAuthServerFromModel_UnsetOptionalBool(t *testing.T) {
 }
 
 // TestModelFromAuthServer_ADFieldsOnly verifies the connection-method
-// branching in modelFromAuthServer: for an "ad" server, only the AD fields
-// are populated from the API response - LDAP fields stay at their zero
-// value (null), and vice versa for TestModelFromAuthServer_LDAPFieldsOnly.
+// branching in modelFromAuthServer: for an "ad" server, every AD field
+// (ADAccountSuffix, ADDomainControllers) plus the shared fields (BaseDN,
+// SecurityLevel) are populated from the API response, while the LDAP-only
+// fields stay at their zero value (null) - and vice versa for
+// TestModelFromAuthServer_LDAPFieldsOnly.
 func TestModelFromAuthServer_ADFieldsOnly(t *testing.T) {
 	a := &client.AuthServer{
 		ServerID:            "abc123",
@@ -58,6 +69,7 @@ func TestModelFromAuthServer_ADFieldsOnly(t *testing.T) {
 		BaseDN:              "DC=example,DC=com",
 		SecurityLevel:       "ssl",
 		LDAPHost:            "should-be-ignored.example.com",
+		LDAPPort:            "should-be-ignored",
 	}
 
 	var m authServerModel
@@ -69,21 +81,34 @@ func TestModelFromAuthServer_ADFieldsOnly(t *testing.T) {
 	if m.ADAccountSuffix.ValueString() != "@example.com" {
 		t.Errorf("ADAccountSuffix = %q, want @example.com", m.ADAccountSuffix.ValueString())
 	}
+	if m.ADDomainControllers.ValueString() != "dc1.example.com" {
+		t.Errorf("ADDomainControllers = %q, want dc1.example.com", m.ADDomainControllers.ValueString())
+	}
+	if m.BaseDN.ValueString() != "DC=example,DC=com" {
+		t.Errorf("BaseDN = %q, want DC=example,DC=com", m.BaseDN.ValueString())
+	}
+	if m.SecurityLevel.ValueString() != "ssl" {
+		t.Errorf("SecurityLevel = %q, want ssl", m.SecurityLevel.ValueString())
+	}
 	if !m.LDAPHost.IsNull() {
 		t.Errorf("LDAPHost = %#v, want null for an ad-connection-method server", m.LDAPHost)
+	}
+	if !m.LDAPPort.IsNull() {
+		t.Errorf("LDAPPort = %#v, want null for an ad-connection-method server", m.LDAPPort)
 	}
 }
 
 func TestModelFromAuthServer_LDAPFieldsOnly(t *testing.T) {
 	a := &client.AuthServer{
-		ServerID:         "abc123",
-		Enabled:          "1",
-		ConnectionMethod: "ldap",
-		LDAPHost:         "ldap.example.com",
-		LDAPPort:         "389",
-		BaseDN:           "DC=example,DC=com",
-		SecurityLevel:    "tls",
-		ADAccountSuffix:  "should-be-ignored",
+		ServerID:            "abc123",
+		Enabled:             "1",
+		ConnectionMethod:    "ldap",
+		LDAPHost:            "ldap.example.com",
+		LDAPPort:            "389",
+		BaseDN:              "DC=example,DC=com",
+		SecurityLevel:       "tls",
+		ADAccountSuffix:     "should-be-ignored",
+		ADDomainControllers: "should-be-ignored",
 	}
 
 	var m authServerModel
@@ -92,7 +117,40 @@ func TestModelFromAuthServer_LDAPFieldsOnly(t *testing.T) {
 	if m.LDAPHost.ValueString() != "ldap.example.com" {
 		t.Errorf("LDAPHost = %q, want ldap.example.com", m.LDAPHost.ValueString())
 	}
+	if m.LDAPPort.ValueString() != "389" {
+		t.Errorf("LDAPPort = %q, want 389", m.LDAPPort.ValueString())
+	}
+	if m.BaseDN.ValueString() != "DC=example,DC=com" {
+		t.Errorf("BaseDN = %q, want DC=example,DC=com", m.BaseDN.ValueString())
+	}
+	if m.SecurityLevel.ValueString() != "tls" {
+		t.Errorf("SecurityLevel = %q, want tls", m.SecurityLevel.ValueString())
+	}
 	if !m.ADAccountSuffix.IsNull() {
 		t.Errorf("ADAccountSuffix = %#v, want null for an ldap-connection-method server", m.ADAccountSuffix)
+	}
+	if !m.ADDomainControllers.IsNull() {
+		t.Errorf("ADDomainControllers = %#v, want null for an ldap-connection-method server", m.ADDomainControllers)
+	}
+}
+
+// TestModelFromAuthServer_UnrecognizedConnectionMethod covers the branch's
+// implicit else: modelFromAuthServer only special-cases the literal string
+// "ad" (see resource_authserver.go) - anything else, including an empty
+// string (a server whose connection_method Nagios omits from the response),
+// falls into the LDAP branch.
+func TestModelFromAuthServer_UnrecognizedConnectionMethod(t *testing.T) {
+	a := &client.AuthServer{
+		ServerID:         "abc123",
+		Enabled:          "1",
+		ConnectionMethod: "",
+		LDAPHost:         "ldap.example.com",
+	}
+
+	var m authServerModel
+	modelFromAuthServer(&m, a)
+
+	if m.LDAPHost.ValueString() != "ldap.example.com" {
+		t.Errorf("LDAPHost = %q, want ldap.example.com - an empty connection_method falls into the LDAP branch", m.LDAPHost.ValueString())
 	}
 }

--- a/internal/provider/resource_authserver_convert_test.go
+++ b/internal/provider/resource_authserver_convert_test.go
@@ -1,0 +1,98 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/dunkin0486/terraform-provider-nagios/internal/client"
+)
+
+func TestAuthServerFromModel(t *testing.T) {
+	m := &authServerModel{
+		Enabled:          types.BoolValue(true),
+		ConnectionMethod: types.StringValue("ldap"),
+		LDAPHost:         types.StringValue("ldap.example.com"),
+		LDAPPort:         types.StringValue("389"),
+		BaseDN:           types.StringValue("DC=example,DC=com"),
+		SecurityLevel:    types.StringValue("tls"),
+	}
+
+	a := authServerFromModel(m)
+
+	if a.Enabled != "1" {
+		t.Errorf("Enabled = %q, want 1", a.Enabled)
+	}
+	if a.ConnectionMethod != "ldap" {
+		t.Errorf("ConnectionMethod = %q, want ldap", a.ConnectionMethod)
+	}
+	if a.LDAPHost != "ldap.example.com" {
+		t.Errorf("LDAPHost = %q, want ldap.example.com", a.LDAPHost)
+	}
+}
+
+func TestAuthServerFromModel_UnsetOptionalBool(t *testing.T) {
+	m := &authServerModel{
+		Enabled:          types.BoolNull(),
+		ConnectionMethod: types.StringValue("ldap"),
+	}
+
+	a := authServerFromModel(m)
+
+	if a.Enabled != "" {
+		t.Errorf("Enabled = %q, want \"\" (omitted) for an unset optional bool", a.Enabled)
+	}
+}
+
+// TestModelFromAuthServer_ADFieldsOnly verifies the connection-method
+// branching in modelFromAuthServer: for an "ad" server, only the AD fields
+// are populated from the API response - LDAP fields stay at their zero
+// value (null), and vice versa for TestModelFromAuthServer_LDAPFieldsOnly.
+func TestModelFromAuthServer_ADFieldsOnly(t *testing.T) {
+	a := &client.AuthServer{
+		ServerID:            "abc123",
+		Enabled:             "1",
+		ConnectionMethod:    "ad",
+		ADAccountSuffix:     "@example.com",
+		ADDomainControllers: "dc1.example.com",
+		BaseDN:              "DC=example,DC=com",
+		SecurityLevel:       "ssl",
+		LDAPHost:            "should-be-ignored.example.com",
+	}
+
+	var m authServerModel
+	modelFromAuthServer(&m, a)
+
+	if m.ServerID.ValueString() != "abc123" {
+		t.Errorf("ServerID = %q, want abc123", m.ServerID.ValueString())
+	}
+	if m.ADAccountSuffix.ValueString() != "@example.com" {
+		t.Errorf("ADAccountSuffix = %q, want @example.com", m.ADAccountSuffix.ValueString())
+	}
+	if !m.LDAPHost.IsNull() {
+		t.Errorf("LDAPHost = %#v, want null for an ad-connection-method server", m.LDAPHost)
+	}
+}
+
+func TestModelFromAuthServer_LDAPFieldsOnly(t *testing.T) {
+	a := &client.AuthServer{
+		ServerID:         "abc123",
+		Enabled:          "1",
+		ConnectionMethod: "ldap",
+		LDAPHost:         "ldap.example.com",
+		LDAPPort:         "389",
+		BaseDN:           "DC=example,DC=com",
+		SecurityLevel:    "tls",
+		ADAccountSuffix:  "should-be-ignored",
+	}
+
+	var m authServerModel
+	modelFromAuthServer(&m, a)
+
+	if m.LDAPHost.ValueString() != "ldap.example.com" {
+		t.Errorf("LDAPHost = %q, want ldap.example.com", m.LDAPHost.ValueString())
+	}
+	if !m.ADAccountSuffix.IsNull() {
+		t.Errorf("ADAccountSuffix = %#v, want null for an ldap-connection-method server", m.ADAccountSuffix)
+	}
+}

--- a/internal/provider/resource_contact_convert_test.go
+++ b/internal/provider/resource_contact_convert_test.go
@@ -1,0 +1,115 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/dunkin0486/terraform-provider-nagios/internal/client"
+)
+
+func TestContactFromModel_FullyPopulated(t *testing.T) {
+	ctx := context.Background()
+
+	hostCommands, _ := types.SetValueFrom(ctx, types.StringType, []string{"notify-host-by-email"})
+	serviceCommands, _ := types.SetValueFrom(ctx, types.StringType, []string{"notify-service-by-email"})
+	contactGroups, _ := types.SetValueFrom(ctx, types.StringType, []string{"admins"})
+
+	m := &contactModel{
+		ContactName:                 types.StringValue("jdoe"),
+		HostNotificationsEnabled:    types.BoolValue(true),
+		ServiceNotificationsEnabled: types.BoolValue(true),
+		HostNotificationPeriod:      types.StringValue("24x7"),
+		ServiceNotificationPeriod:   types.StringValue("24x7"),
+		HostNotificationOptions:     types.StringValue("d,u,r"),
+		ServiceNotificationOptions:  types.StringValue("w,u,c,r"),
+		HostNotificationCommands:    hostCommands,
+		ServiceNotificationCommands: serviceCommands,
+		Alias:                       types.StringValue("Jane Doe"),
+		ContactGroups:               contactGroups,
+		Email:                       types.StringValue("jane@example.com"),
+		CanSubmitCommands:           types.BoolValue(false),
+	}
+
+	c, diags := contactFromModel(ctx, m)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if c.ContactName != "jdoe" {
+		t.Errorf("ContactName = %q, want jdoe", c.ContactName)
+	}
+	if c.HostNotificationsEnabled != "1" {
+		t.Errorf("HostNotificationsEnabled = %q, want 1", c.HostNotificationsEnabled)
+	}
+	if c.CanSubmitCommands != "0" {
+		t.Errorf("CanSubmitCommands = %q, want 0", c.CanSubmitCommands)
+	}
+	if len(c.ContactGroups) != 1 || c.ContactGroups[0] != "admins" {
+		t.Errorf("ContactGroups = %#v, want [admins]", c.ContactGroups)
+	}
+}
+
+func TestContactFromModel_UnsetOptionalBool(t *testing.T) {
+	ctx := context.Background()
+
+	hostCommands, _ := types.SetValueFrom(ctx, types.StringType, []string{"notify-host-by-email"})
+	serviceCommands, _ := types.SetValueFrom(ctx, types.StringType, []string{"notify-service-by-email"})
+
+	m := &contactModel{
+		ContactName:                 types.StringValue("jdoe"),
+		HostNotificationsEnabled:    types.BoolValue(true),
+		ServiceNotificationsEnabled: types.BoolValue(true),
+		HostNotificationPeriod:      types.StringValue("24x7"),
+		ServiceNotificationPeriod:   types.StringValue("24x7"),
+		HostNotificationOptions:     types.StringValue("d,u,r"),
+		ServiceNotificationOptions:  types.StringValue("w,u,c,r"),
+		HostNotificationCommands:    hostCommands,
+		ServiceNotificationCommands: serviceCommands,
+		CanSubmitCommands:           types.BoolNull(),
+	}
+
+	c, diags := contactFromModel(ctx, m)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if c.CanSubmitCommands != "" {
+		t.Errorf("CanSubmitCommands = %q, want \"\" (omitted) for an unset optional bool", c.CanSubmitCommands)
+	}
+}
+
+func TestModelFromContact_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	c := &client.Contact{
+		ContactName:                 "jdoe",
+		HostNotificationsEnabled:    "1",
+		ServiceNotificationsEnabled: "1",
+		HostNotificationPeriod:      "24x7",
+		ServiceNotificationPeriod:   "24x7",
+		HostNotificationOptions:     "d,u,r",
+		ServiceNotificationOptions:  "w,u,c,r",
+		HostNotificationCommands:    []string{"notify-host-by-email"},
+		ServiceNotificationCommands: []string{"notify-service-by-email"},
+		Email:                       "jane@example.com",
+		CanSubmitCommands:           "0",
+	}
+
+	var m contactModel
+	diags := modelFromContact(ctx, &m, c)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if m.ContactName.ValueString() != "jdoe" {
+		t.Errorf("ContactName = %q, want jdoe", m.ContactName.ValueString())
+	}
+	if m.CanSubmitCommands.ValueBool() {
+		t.Errorf("CanSubmitCommands = %v, want false", m.CanSubmitCommands)
+	}
+	if !m.Alias.IsNull() {
+		t.Errorf("Alias = %#v, want null for an empty API response value", m.Alias)
+	}
+}

--- a/internal/provider/resource_contactgroup_convert_test.go
+++ b/internal/provider/resource_contactgroup_convert_test.go
@@ -59,4 +59,13 @@ func TestModelFromContactgroup(t *testing.T) {
 	if !m.ContactgroupMembers.IsNull() {
 		t.Errorf("ContactgroupMembers = %#v, want null for an empty API response value", m.ContactgroupMembers)
 	}
+
+	var members []string
+	diags = m.Members.ElementsAs(ctx, &members, false)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics reading Members: %v", diags)
+	}
+	if len(members) != 1 || members[0] != "jdoe" {
+		t.Errorf("Members = %#v, want [jdoe]", members)
+	}
 }

--- a/internal/provider/resource_contactgroup_convert_test.go
+++ b/internal/provider/resource_contactgroup_convert_test.go
@@ -1,0 +1,62 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/dunkin0486/terraform-provider-nagios/internal/client"
+)
+
+func TestContactgroupFromModel(t *testing.T) {
+	ctx := context.Background()
+
+	members, _ := types.SetValueFrom(ctx, types.StringType, []string{"jdoe"})
+	nestedGroups, _ := types.SetValueFrom(ctx, types.StringType, []string{"on-call"})
+
+	m := &contactgroupModel{
+		ContactgroupName:    types.StringValue("admins"),
+		Alias:               types.StringValue("Admins"),
+		Members:             members,
+		ContactgroupMembers: nestedGroups,
+	}
+
+	cg, diags := contactgroupFromModel(ctx, m)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if cg.ContactgroupName != "admins" {
+		t.Errorf("ContactgroupName = %q, want admins", cg.ContactgroupName)
+	}
+	if len(cg.Members) != 1 || cg.Members[0] != "jdoe" {
+		t.Errorf("Members = %#v, want [jdoe]", cg.Members)
+	}
+	if len(cg.ContactgroupMembers) != 1 || cg.ContactgroupMembers[0] != "on-call" {
+		t.Errorf("ContactgroupMembers = %#v, want [on-call]", cg.ContactgroupMembers)
+	}
+}
+
+func TestModelFromContactgroup(t *testing.T) {
+	ctx := context.Background()
+
+	cg := &client.Contactgroup{
+		ContactgroupName: "admins",
+		Alias:            "Admins",
+		Members:          []string{"jdoe"},
+	}
+
+	var m contactgroupModel
+	diags := modelFromContactgroup(ctx, &m, cg)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if m.ContactgroupName.ValueString() != "admins" {
+		t.Errorf("ContactgroupName = %q, want admins", m.ContactgroupName.ValueString())
+	}
+	if !m.ContactgroupMembers.IsNull() {
+		t.Errorf("ContactgroupMembers = %#v, want null for an empty API response value", m.ContactgroupMembers)
+	}
+}

--- a/internal/provider/resource_host_convert_test.go
+++ b/internal/provider/resource_host_convert_test.go
@@ -1,0 +1,187 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/dunkin0486/terraform-provider-nagios/internal/client"
+)
+
+func TestHostFromModel_FullyPopulated(t *testing.T) {
+	ctx := context.Background()
+
+	contacts, _ := types.SetValueFrom(ctx, types.StringType, []string{"nagiosadmin"})
+	templates, _ := types.SetValueFrom(ctx, types.StringType, []string{"generic-host"})
+	contactGroups, _ := types.SetValueFrom(ctx, types.StringType, []string{"admins"})
+	parents, _ := types.SetValueFrom(ctx, types.StringType, []string{"router1"})
+	flapOptions, _ := types.SetValueFrom(ctx, types.StringType, []string{"o", "d"})
+	freeVars, _ := types.MapValueFrom(ctx, types.StringType, map[string]string{"_ENV": "prod"})
+
+	m := &hostModel{
+		HostName:             types.StringValue("web01"),
+		Address:              types.StringValue("10.0.0.1"),
+		DisplayName:          types.StringValue("Web 01"),
+		MaxCheckAttempts:     types.StringValue("3"),
+		CheckPeriod:          types.StringValue("24x7"),
+		NotificationInterval: types.StringValue("30"),
+		NotificationPeriod:   types.StringValue("24x7"),
+		Contacts:             contacts,
+		Alias:                types.StringValue("Web Server"),
+		Templates:            templates,
+		CheckCommand:         types.StringValue("check-host-alive"),
+		ContactGroups:        contactGroups,
+		Parents:              parents,
+		Notes:                types.StringValue("note"),
+		NotesURL:             types.StringValue("https://example.com/notes"),
+		ActionURL:            types.StringValue("https://example.com/action"),
+		InitialState:         types.StringValue("o"),
+		RetryInterval:        types.StringValue("1"),
+		PassiveChecksEnabled: types.BoolValue(true),
+		ActiveChecksEnabled:  types.BoolValue(false),
+		FlapDetectionOptions: flapOptions,
+		Register:             types.BoolValue(true),
+		FreeVariables:        freeVars,
+	}
+
+	h, diags := hostFromModel(ctx, m)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if h.HostName != "web01" {
+		t.Errorf("HostName = %q, want web01", h.HostName)
+	}
+	if h.Address != "10.0.0.1" {
+		t.Errorf("Address = %q, want 10.0.0.1", h.Address)
+	}
+	if len(h.Contacts) != 1 || h.Contacts[0] != "nagiosadmin" {
+		t.Errorf("Contacts = %#v, want [nagiosadmin]", h.Contacts)
+	}
+	if len(h.Parents) != 1 || h.Parents[0] != "router1" {
+		t.Errorf("Parents = %#v, want [router1]", h.Parents)
+	}
+	if h.PassiveChecksEnabled != "1" {
+		t.Errorf("PassiveChecksEnabled = %q, want 1", h.PassiveChecksEnabled)
+	}
+	if h.ActiveChecksEnabled != "0" {
+		t.Errorf("ActiveChecksEnabled = %q, want 0", h.ActiveChecksEnabled)
+	}
+	if h.FreeVariables["_ENV"] != "prod" {
+		t.Errorf("FreeVariables = %#v, want map[_ENV:prod]", h.FreeVariables)
+	}
+}
+
+// TestHostFromModel_UnsetOptionalBool is the direct regression test for the
+// historically-shipped bug: an unset (null) optional bool must be omitted
+// ("") from the request, never silently sent as an explicit "0".
+func TestHostFromModel_UnsetOptionalBool(t *testing.T) {
+	ctx := context.Background()
+
+	m := &hostModel{
+		HostName:             types.StringValue("web01"),
+		Address:              types.StringValue("10.0.0.1"),
+		MaxCheckAttempts:     types.StringValue("3"),
+		CheckPeriod:          types.StringValue("24x7"),
+		NotificationInterval: types.StringValue("30"),
+		NotificationPeriod:   types.StringValue("24x7"),
+		Contacts:             types.SetNull(types.StringType),
+		PassiveChecksEnabled: types.BoolNull(),
+		Parents:              types.SetNull(types.StringType),
+		FreeVariables:        types.MapNull(types.StringType),
+	}
+
+	h, diags := hostFromModel(ctx, m)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if h.PassiveChecksEnabled != "" {
+		t.Errorf("PassiveChecksEnabled = %q, want \"\" (omitted) for an unset optional bool", h.PassiveChecksEnabled)
+	}
+	if h.Parents != nil {
+		t.Errorf("Parents = %#v, want nil for an unset optional set", h.Parents)
+	}
+}
+
+func TestModelFromHost_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	h := &client.Host{
+		HostName:             "web01",
+		Address:              "10.0.0.1",
+		MaxCheckAttempts:     "3",
+		CheckPeriod:          "24x7",
+		NotificationInterval: "30",
+		NotificationPeriod:   "24x7",
+		Contacts:             []string{"nagiosadmin"},
+		Parents:              []string{"router1"},
+		PassiveChecksEnabled: "1",
+		ActiveChecksEnabled:  "",
+		FreeVariables:        map[string]string{"_ENV": "prod"},
+	}
+
+	var m hostModel
+	diags := modelFromHost(ctx, &m, h)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if m.HostName.ValueString() != "web01" {
+		t.Errorf("HostName = %q, want web01", m.HostName.ValueString())
+	}
+	if !m.PassiveChecksEnabled.ValueBool() {
+		t.Errorf("PassiveChecksEnabled = %v, want true", m.PassiveChecksEnabled)
+	}
+	if !m.ActiveChecksEnabled.IsNull() {
+		t.Errorf("ActiveChecksEnabled = %#v, want null for an empty API response value", m.ActiveChecksEnabled)
+	}
+
+	var parents []string
+	diags = m.Parents.ElementsAs(ctx, &parents, false)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics reading Parents: %v", diags)
+	}
+	if len(parents) != 1 || parents[0] != "router1" {
+		t.Errorf("Parents = %#v, want [router1]", parents)
+	}
+
+	var freeVars map[string]string
+	diags = m.FreeVariables.ElementsAs(ctx, &freeVars, false)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics reading FreeVariables: %v", diags)
+	}
+	if freeVars["_ENV"] != "prod" {
+		t.Errorf("FreeVariables = %#v, want map[_ENV:prod]", freeVars)
+	}
+}
+
+func TestModelFromHost_EmptyOptionalsBecomeNull(t *testing.T) {
+	ctx := context.Background()
+
+	h := &client.Host{
+		HostName:             "web01",
+		Address:              "10.0.0.1",
+		MaxCheckAttempts:     "3",
+		CheckPeriod:          "24x7",
+		NotificationInterval: "30",
+		NotificationPeriod:   "24x7",
+	}
+
+	var m hostModel
+	diags := modelFromHost(ctx, &m, h)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if !m.Alias.IsNull() {
+		t.Errorf("Alias = %#v, want null for an empty API response value", m.Alias)
+	}
+	if !m.Parents.IsNull() {
+		t.Errorf("Parents = %#v, want null for an empty API response value", m.Parents)
+	}
+	if !m.FreeVariables.IsNull() {
+		t.Errorf("FreeVariables = %#v, want null for an empty API response value", m.FreeVariables)
+	}
+}

--- a/internal/provider/resource_host_convert_test.go
+++ b/internal/provider/resource_host_convert_test.go
@@ -38,10 +38,7 @@ func TestHostFromModel_FullyPopulated(t *testing.T) {
 		ActionURL:            types.StringValue("https://example.com/action"),
 		InitialState:         types.StringValue("o"),
 		RetryInterval:        types.StringValue("1"),
-		PassiveChecksEnabled: types.BoolValue(true),
-		ActiveChecksEnabled:  types.BoolValue(false),
 		FlapDetectionOptions: flapOptions,
-		Register:             types.BoolValue(true),
 		FreeVariables:        freeVars,
 	}
 
@@ -56,17 +53,32 @@ func TestHostFromModel_FullyPopulated(t *testing.T) {
 	if h.Address != "10.0.0.1" {
 		t.Errorf("Address = %q, want 10.0.0.1", h.Address)
 	}
+	if h.DisplayName != "Web 01" {
+		t.Errorf("DisplayName = %q, want \"Web 01\"", h.DisplayName)
+	}
+	if h.Alias != "Web Server" {
+		t.Errorf("Alias = %q, want \"Web Server\"", h.Alias)
+	}
+	if h.CheckCommand != "check-host-alive" {
+		t.Errorf("CheckCommand = %q, want check-host-alive", h.CheckCommand)
+	}
+	if h.Notes != "note" {
+		t.Errorf("Notes = %q, want note", h.Notes)
+	}
 	if len(h.Contacts) != 1 || h.Contacts[0] != "nagiosadmin" {
 		t.Errorf("Contacts = %#v, want [nagiosadmin]", h.Contacts)
+	}
+	if len(h.Templates) != 1 || h.Templates[0] != "generic-host" {
+		t.Errorf("Templates = %#v, want [generic-host]", h.Templates)
+	}
+	if len(h.ContactGroups) != 1 || h.ContactGroups[0] != "admins" {
+		t.Errorf("ContactGroups = %#v, want [admins]", h.ContactGroups)
 	}
 	if len(h.Parents) != 1 || h.Parents[0] != "router1" {
 		t.Errorf("Parents = %#v, want [router1]", h.Parents)
 	}
-	if h.PassiveChecksEnabled != "1" {
-		t.Errorf("PassiveChecksEnabled = %q, want 1", h.PassiveChecksEnabled)
-	}
-	if h.ActiveChecksEnabled != "0" {
-		t.Errorf("ActiveChecksEnabled = %q, want 0", h.ActiveChecksEnabled)
+	if len(h.FlapDetectionOptions) != 2 {
+		t.Errorf("FlapDetectionOptions = %#v, want 2 elements", h.FlapDetectionOptions)
 	}
 	if h.FreeVariables["_ENV"] != "prod" {
 		t.Errorf("FreeVariables = %#v, want map[_ENV:prod]", h.FreeVariables)
@@ -105,6 +117,163 @@ func TestHostFromModel_UnsetOptionalBool(t *testing.T) {
 	}
 }
 
+// hostBoolField describes one of hostModel's optional bool attributes for
+// the field-isolation tests below: set/get on the model side, get on the
+// client.Host side.
+type hostBoolField struct {
+	name      string
+	setModel  func(m *hostModel, v types.Bool)
+	getClient func(h *client.Host) string
+	setClient func(h *client.Host, v string)
+	getModel  func(m *hostModel) types.Bool
+}
+
+// hostBoolFields covers every optional bool field hostFromModel/modelFromHost
+// maps - see resource_host.go. Kept as a single source of truth so both
+// directions' isolation tests below stay in sync with the schema.
+var hostBoolFields = []hostBoolField{
+	{"passive_checks_enabled",
+		func(m *hostModel, v types.Bool) { m.PassiveChecksEnabled = v },
+		func(h *client.Host) string { return h.PassiveChecksEnabled },
+		func(h *client.Host, v string) { h.PassiveChecksEnabled = v },
+		func(m *hostModel) types.Bool { return m.PassiveChecksEnabled }},
+	{"active_checks_enabled",
+		func(m *hostModel, v types.Bool) { m.ActiveChecksEnabled = v },
+		func(h *client.Host) string { return h.ActiveChecksEnabled },
+		func(h *client.Host, v string) { h.ActiveChecksEnabled = v },
+		func(m *hostModel) types.Bool { return m.ActiveChecksEnabled }},
+	{"obsess_over_host",
+		func(m *hostModel, v types.Bool) { m.ObsessOverHost = v },
+		func(h *client.Host) string { return h.ObsessOverHost },
+		func(h *client.Host, v string) { h.ObsessOverHost = v },
+		func(m *hostModel) types.Bool { return m.ObsessOverHost }},
+	{"event_handler_enabled",
+		func(m *hostModel, v types.Bool) { m.EventHandlerEnabled = v },
+		func(h *client.Host) string { return h.EventHandlerEnabled },
+		func(h *client.Host, v string) { h.EventHandlerEnabled = v },
+		func(m *hostModel) types.Bool { return m.EventHandlerEnabled }},
+	{"flap_detection_enabled",
+		func(m *hostModel, v types.Bool) { m.FlapDetectionEnabled = v },
+		func(h *client.Host) string { return h.FlapDetectionEnabled },
+		func(h *client.Host, v string) { h.FlapDetectionEnabled = v },
+		func(m *hostModel) types.Bool { return m.FlapDetectionEnabled }},
+	{"process_perf_data",
+		func(m *hostModel, v types.Bool) { m.ProcessPerfData = v },
+		func(h *client.Host) string { return h.ProcessPerfData },
+		func(h *client.Host, v string) { h.ProcessPerfData = v },
+		func(m *hostModel) types.Bool { return m.ProcessPerfData }},
+	{"retain_status_information",
+		func(m *hostModel, v types.Bool) { m.RetainStatusInformation = v },
+		func(h *client.Host) string { return h.RetainStatusInformation },
+		func(h *client.Host, v string) { h.RetainStatusInformation = v },
+		func(m *hostModel) types.Bool { return m.RetainStatusInformation }},
+	{"retain_nonstatus_information",
+		func(m *hostModel, v types.Bool) { m.RetainNonstatusInformation = v },
+		func(h *client.Host) string { return h.RetainNonstatusInformation },
+		func(h *client.Host, v string) { h.RetainNonstatusInformation = v },
+		func(m *hostModel) types.Bool { return m.RetainNonstatusInformation }},
+	{"check_freshness",
+		func(m *hostModel, v types.Bool) { m.CheckFreshness = v },
+		func(h *client.Host) string { return h.CheckFreshness },
+		func(h *client.Host, v string) { h.CheckFreshness = v },
+		func(m *hostModel) types.Bool { return m.CheckFreshness }},
+	{"notifications_enabled",
+		func(m *hostModel, v types.Bool) { m.NotificationsEnabled = v },
+		func(h *client.Host) string { return h.NotificationsEnabled },
+		func(h *client.Host, v string) { h.NotificationsEnabled = v },
+		func(m *hostModel) types.Bool { return m.NotificationsEnabled }},
+	{"register",
+		func(m *hostModel, v types.Bool) { m.Register = v },
+		func(h *client.Host) string { return h.Register },
+		func(h *client.Host, v string) { h.Register = v },
+		func(m *hostModel) types.Bool { return m.Register }},
+}
+
+func baseHostModel() hostModel {
+	return hostModel{
+		HostName:             types.StringValue("web01"),
+		Address:              types.StringValue("10.0.0.1"),
+		MaxCheckAttempts:     types.StringValue("3"),
+		CheckPeriod:          types.StringValue("24x7"),
+		NotificationInterval: types.StringValue("30"),
+		NotificationPeriod:   types.StringValue("24x7"),
+	}
+}
+
+// TestHostFromModel_AllBoolFields sets exactly one bool field at a time and
+// verifies both that it maps to the right client.Host field AND that every
+// other bool field stays unset ("") - the isolation catches a swapped/
+// copy-pasted mapping between two of hostFromModel's 11 nearly-identical
+// optionalBoolToNagios(...) lines, which a test that sets several fields at
+// once would not reliably catch.
+func TestHostFromModel_AllBoolFields(t *testing.T) {
+	ctx := context.Background()
+
+	for _, field := range hostBoolFields {
+		t.Run(field.name, func(t *testing.T) {
+			m := baseHostModel()
+			field.setModel(&m, types.BoolValue(true))
+
+			h, diags := hostFromModel(ctx, &m)
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics: %v", diags)
+			}
+
+			if got := field.getClient(h); got != "1" {
+				t.Errorf("setting %s = true produced %q, want \"1\"", field.name, got)
+			}
+
+			for _, other := range hostBoolFields {
+				if other.name == field.name {
+					continue
+				}
+				if got := other.getClient(h); got != "" {
+					t.Errorf("setting only %s leaked into %s (got %q, want \"\" since %s was never set)", field.name, other.name, got, other.name)
+				}
+			}
+		})
+	}
+}
+
+// TestModelFromHost_AllBoolFields is the mirror of
+// TestHostFromModel_AllBoolFields for the read path.
+func TestModelFromHost_AllBoolFields(t *testing.T) {
+	ctx := context.Background()
+
+	for _, field := range hostBoolFields {
+		t.Run(field.name, func(t *testing.T) {
+			h := &client.Host{
+				HostName:             "web01",
+				Address:              "10.0.0.1",
+				MaxCheckAttempts:     "3",
+				CheckPeriod:          "24x7",
+				NotificationInterval: "30",
+				NotificationPeriod:   "24x7",
+			}
+			field.setClient(h, "1")
+
+			var m hostModel
+			diags := modelFromHost(ctx, &m, h)
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics: %v", diags)
+			}
+
+			if got := field.getModel(&m); got.IsNull() || !got.ValueBool() {
+				t.Errorf("setting %s = \"1\" produced %#v, want true", field.name, got)
+			}
+
+			for _, other := range hostBoolFields {
+				if other.name == field.name {
+					continue
+				}
+				if got := other.getModel(&m); !got.IsNull() {
+					t.Errorf("setting only %s leaked into %s (got %#v, want null since %s was never set)", field.name, other.name, got, other.name)
+				}
+			}
+		})
+	}
+}
+
 func TestModelFromHost_RoundTrip(t *testing.T) {
 	ctx := context.Background()
 
@@ -117,8 +286,6 @@ func TestModelFromHost_RoundTrip(t *testing.T) {
 		NotificationPeriod:   "24x7",
 		Contacts:             []string{"nagiosadmin"},
 		Parents:              []string{"router1"},
-		PassiveChecksEnabled: "1",
-		ActiveChecksEnabled:  "",
 		FreeVariables:        map[string]string{"_ENV": "prod"},
 	}
 
@@ -130,12 +297,6 @@ func TestModelFromHost_RoundTrip(t *testing.T) {
 
 	if m.HostName.ValueString() != "web01" {
 		t.Errorf("HostName = %q, want web01", m.HostName.ValueString())
-	}
-	if !m.PassiveChecksEnabled.ValueBool() {
-		t.Errorf("PassiveChecksEnabled = %v, want true", m.PassiveChecksEnabled)
-	}
-	if !m.ActiveChecksEnabled.IsNull() {
-		t.Errorf("ActiveChecksEnabled = %#v, want null for an empty API response value", m.ActiveChecksEnabled)
 	}
 
 	var parents []string

--- a/internal/provider/resource_hostgroup_convert_test.go
+++ b/internal/provider/resource_hostgroup_convert_test.go
@@ -1,0 +1,71 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/dunkin0486/terraform-provider-nagios/internal/client"
+)
+
+func TestHostgroupFromModel(t *testing.T) {
+	ctx := context.Background()
+
+	members, _ := types.SetValueFrom(ctx, types.StringType, []string{"web01", "web02"})
+	m := &hostgroupModel{
+		Name:      types.StringValue("web-servers"),
+		Alias:     types.StringValue("Web Servers"),
+		Members:   members,
+		Notes:     types.StringValue("note"),
+		NotesURL:  types.StringValue("https://example.com/notes"),
+		ActionURL: types.StringValue("https://example.com/action"),
+	}
+
+	hg, diags := hostgroupFromModel(ctx, m)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if hg.Name != "web-servers" {
+		t.Errorf("Name = %q, want web-servers", hg.Name)
+	}
+	if len(hg.Members) != 2 {
+		t.Errorf("Members = %#v, want 2 elements", hg.Members)
+	}
+	if hg.Notes != "note" {
+		t.Errorf("Notes = %q, want note", hg.Notes)
+	}
+}
+
+func TestModelFromHostgroup(t *testing.T) {
+	ctx := context.Background()
+
+	hg := &client.Hostgroup{
+		Name:    "web-servers",
+		Alias:   "Web Servers",
+		Members: []string{"web01"},
+	}
+
+	var m hostgroupModel
+	diags := modelFromHostgroup(ctx, &m, hg)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if m.Name.ValueString() != "web-servers" {
+		t.Errorf("Name = %q, want web-servers", m.Name.ValueString())
+	}
+	if !m.Notes.IsNull() {
+		t.Errorf("Notes = %#v, want null for an empty API response value", m.Notes)
+	}
+
+	var members []string
+	diags = m.Members.ElementsAs(ctx, &members, false)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics reading Members: %v", diags)
+	}
+	if len(members) != 1 || members[0] != "web01" {
+		t.Errorf("Members = %#v, want [web01]", members)
+	}
+}

--- a/internal/provider/resource_service_convert_test.go
+++ b/internal/provider/resource_service_convert_test.go
@@ -14,6 +14,8 @@ func TestServiceFromModel_FullyPopulated(t *testing.T) {
 
 	hostName, _ := types.SetValueFrom(ctx, types.StringType, []string{"web01", "web02"})
 	contacts, _ := types.SetValueFrom(ctx, types.StringType, []string{"nagiosadmin"})
+	templates, _ := types.SetValueFrom(ctx, types.StringType, []string{"generic-service"})
+	contactGroups, _ := types.SetValueFrom(ctx, types.StringType, []string{"admins"})
 	notificationOptions, _ := types.SetValueFrom(ctx, types.StringType, []string{"w", "c"})
 	freeVars, _ := types.MapValueFrom(ctx, types.StringType, map[string]string{"_TIER": "web"})
 
@@ -29,10 +31,9 @@ func TestServiceFromModel_FullyPopulated(t *testing.T) {
 		NotificationInterval: types.StringValue("30"),
 		NotificationPeriod:   types.StringValue("24x7"),
 		Contacts:             contacts,
-		IsVolatile:           types.BoolValue(false),
-		ActiveChecksEnabled:  types.BoolValue(true),
+		Templates:            templates,
+		ContactGroups:        contactGroups,
 		NotificationOptions:  notificationOptions,
-		Register:             types.BoolValue(true),
 		FreeVariables:        freeVars,
 	}
 
@@ -47,11 +48,14 @@ func TestServiceFromModel_FullyPopulated(t *testing.T) {
 	if len(s.HostName) != 2 {
 		t.Errorf("HostName = %#v, want 2 elements", s.HostName)
 	}
-	if s.IsVolatile != "0" {
-		t.Errorf("IsVolatile = %q, want 0", s.IsVolatile)
+	if s.CheckCommand != "check_http" {
+		t.Errorf("CheckCommand = %q, want check_http", s.CheckCommand)
 	}
-	if s.ActiveChecksEnabled != "1" {
-		t.Errorf("ActiveChecksEnabled = %q, want 1", s.ActiveChecksEnabled)
+	if len(s.Templates) != 1 || s.Templates[0] != "generic-service" {
+		t.Errorf("Templates = %#v, want [generic-service]", s.Templates)
+	}
+	if len(s.ContactGroups) != 1 || s.ContactGroups[0] != "admins" {
+		t.Errorf("ContactGroups = %#v, want [admins]", s.ContactGroups)
 	}
 	if len(s.NotificationOptions) != 2 {
 		t.Errorf("NotificationOptions = %#v, want 2 elements", s.NotificationOptions)
@@ -89,6 +93,174 @@ func TestServiceFromModel_UnsetOptionalBool(t *testing.T) {
 	}
 }
 
+// serviceBoolField describes one of serviceModel's optional bool attributes
+// for the field-isolation tests below - see hostBoolField's doc comment in
+// resource_host_convert_test.go for why isolation (not a blanket alternating
+// pattern) is used.
+type serviceBoolField struct {
+	name      string
+	setModel  func(m *serviceModel, v types.Bool)
+	getClient func(s *client.Service) string
+	setClient func(s *client.Service, v string)
+	getModel  func(m *serviceModel) types.Bool
+}
+
+var serviceBoolFields = []serviceBoolField{
+	{"is_volatile",
+		func(m *serviceModel, v types.Bool) { m.IsVolatile = v },
+		func(s *client.Service) string { return s.IsVolatile },
+		func(s *client.Service, v string) { s.IsVolatile = v },
+		func(m *serviceModel) types.Bool { return m.IsVolatile }},
+	{"active_checks_enabled",
+		func(m *serviceModel, v types.Bool) { m.ActiveChecksEnabled = v },
+		func(s *client.Service) string { return s.ActiveChecksEnabled },
+		func(s *client.Service, v string) { s.ActiveChecksEnabled = v },
+		func(m *serviceModel) types.Bool { return m.ActiveChecksEnabled }},
+	{"passive_checks_enabled",
+		func(m *serviceModel, v types.Bool) { m.PassiveChecksEnabled = v },
+		func(s *client.Service) string { return s.PassiveChecksEnabled },
+		func(s *client.Service, v string) { s.PassiveChecksEnabled = v },
+		func(m *serviceModel) types.Bool { return m.PassiveChecksEnabled }},
+	{"obsess_over_service",
+		func(m *serviceModel, v types.Bool) { m.ObsessOverService = v },
+		func(s *client.Service) string { return s.ObsessOverService },
+		func(s *client.Service, v string) { s.ObsessOverService = v },
+		func(m *serviceModel) types.Bool { return m.ObsessOverService }},
+	{"check_freshness",
+		func(m *serviceModel, v types.Bool) { m.CheckFreshness = v },
+		func(s *client.Service) string { return s.CheckFreshness },
+		func(s *client.Service, v string) { s.CheckFreshness = v },
+		func(m *serviceModel) types.Bool { return m.CheckFreshness }},
+	{"event_handler_enabled",
+		func(m *serviceModel, v types.Bool) { m.EventHandlerEnabled = v },
+		func(s *client.Service) string { return s.EventHandlerEnabled },
+		func(s *client.Service, v string) { s.EventHandlerEnabled = v },
+		func(m *serviceModel) types.Bool { return m.EventHandlerEnabled }},
+	{"flap_detection_enabled",
+		func(m *serviceModel, v types.Bool) { m.FlapDetectionEnabled = v },
+		func(s *client.Service) string { return s.FlapDetectionEnabled },
+		func(s *client.Service, v string) { s.FlapDetectionEnabled = v },
+		func(m *serviceModel) types.Bool { return m.FlapDetectionEnabled }},
+	{"process_perf_data",
+		func(m *serviceModel, v types.Bool) { m.ProcessPerfData = v },
+		func(s *client.Service) string { return s.ProcessPerfData },
+		func(s *client.Service, v string) { s.ProcessPerfData = v },
+		func(m *serviceModel) types.Bool { return m.ProcessPerfData }},
+	{"retain_status_information",
+		func(m *serviceModel, v types.Bool) { m.RetainStatusInformation = v },
+		func(s *client.Service) string { return s.RetainStatusInformation },
+		func(s *client.Service, v string) { s.RetainStatusInformation = v },
+		func(m *serviceModel) types.Bool { return m.RetainStatusInformation }},
+	{"retain_nonstatus_information",
+		func(m *serviceModel, v types.Bool) { m.RetainNonStatusInformation = v },
+		func(s *client.Service) string { return s.RetainNonStatusInformation },
+		func(s *client.Service, v string) { s.RetainNonStatusInformation = v },
+		func(m *serviceModel) types.Bool { return m.RetainNonStatusInformation }},
+	{"notifications_enabled",
+		func(m *serviceModel, v types.Bool) { m.NotificationsEnabled = v },
+		func(s *client.Service) string { return s.NotificationsEnabled },
+		func(s *client.Service, v string) { s.NotificationsEnabled = v },
+		func(m *serviceModel) types.Bool { return m.NotificationsEnabled }},
+	{"register",
+		func(m *serviceModel, v types.Bool) { m.Register = v },
+		func(s *client.Service) string { return s.Register },
+		func(s *client.Service, v string) { s.Register = v },
+		func(m *serviceModel) types.Bool { return m.Register }},
+}
+
+func baseServiceModel(ctx context.Context) serviceModel {
+	hostName, _ := types.SetValueFrom(ctx, types.StringType, []string{"web01"})
+	return serviceModel{
+		ServiceName:          types.StringValue("web01-http"),
+		HostName:             hostName,
+		Description:          types.StringValue("HTTP"),
+		CheckCommand:         types.StringValue("check_http"),
+		MaxCheckAttempts:     types.StringValue("3"),
+		CheckInterval:        types.StringValue("5"),
+		RetryInterval:        types.StringValue("1"),
+		CheckPeriod:          types.StringValue("24x7"),
+		NotificationInterval: types.StringValue("30"),
+		NotificationPeriod:   types.StringValue("24x7"),
+	}
+}
+
+// TestServiceFromModel_AllBoolFields sets exactly one bool field at a time
+// and verifies both that it maps to the right client.Service field AND that
+// every other bool field stays unset - see TestHostFromModel_AllBoolFields
+// for why isolation catches swapped/copy-pasted mappings that a
+// set-everything-at-once test would not.
+func TestServiceFromModel_AllBoolFields(t *testing.T) {
+	ctx := context.Background()
+
+	for _, field := range serviceBoolFields {
+		t.Run(field.name, func(t *testing.T) {
+			m := baseServiceModel(ctx)
+			field.setModel(&m, types.BoolValue(true))
+
+			s, diags := serviceFromModel(ctx, &m)
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics: %v", diags)
+			}
+
+			if got := field.getClient(s); got != "1" {
+				t.Errorf("setting %s = true produced %q, want \"1\"", field.name, got)
+			}
+
+			for _, other := range serviceBoolFields {
+				if other.name == field.name {
+					continue
+				}
+				if got := other.getClient(s); got != "" {
+					t.Errorf("setting only %s leaked into %s (got %q, want \"\" since %s was never set)", field.name, other.name, got, other.name)
+				}
+			}
+		})
+	}
+}
+
+// TestModelFromService_AllBoolFields is the mirror of
+// TestServiceFromModel_AllBoolFields for the read path.
+func TestModelFromService_AllBoolFields(t *testing.T) {
+	ctx := context.Background()
+
+	for _, field := range serviceBoolFields {
+		t.Run(field.name, func(t *testing.T) {
+			s := &client.Service{
+				ServiceName:          "web01-http",
+				HostName:             []string{"web01"},
+				Description:          "HTTP",
+				CheckCommand:         "check_http",
+				MaxCheckAttempts:     "3",
+				CheckInterval:        "5",
+				RetryInterval:        "1",
+				CheckPeriod:          "24x7",
+				NotificationInterval: "30",
+				NotificationPeriod:   "24x7",
+			}
+			field.setClient(s, "1")
+
+			var m serviceModel
+			diags := modelFromService(ctx, &m, s)
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics: %v", diags)
+			}
+
+			if got := field.getModel(&m); got.IsNull() || !got.ValueBool() {
+				t.Errorf("setting %s = \"1\" produced %#v, want true", field.name, got)
+			}
+
+			for _, other := range serviceBoolFields {
+				if other.name == field.name {
+					continue
+				}
+				if got := other.getModel(&m); !got.IsNull() {
+					t.Errorf("setting only %s leaked into %s (got %#v, want null since %s was never set)", field.name, other.name, got, other.name)
+				}
+			}
+		})
+	}
+}
+
 func TestModelFromService_RoundTrip(t *testing.T) {
 	ctx := context.Background()
 
@@ -103,7 +275,6 @@ func TestModelFromService_RoundTrip(t *testing.T) {
 		CheckPeriod:          "24x7",
 		NotificationInterval: "30",
 		NotificationPeriod:   "24x7",
-		IsVolatile:           "1",
 		FreeVariables:        map[string]string{"_TIER": "web"},
 	}
 
@@ -115,9 +286,6 @@ func TestModelFromService_RoundTrip(t *testing.T) {
 
 	if m.ServiceName.ValueString() != "web01-http" {
 		t.Errorf("ServiceName = %q, want web01-http", m.ServiceName.ValueString())
-	}
-	if !m.IsVolatile.ValueBool() {
-		t.Errorf("IsVolatile = %v, want true", m.IsVolatile)
 	}
 
 	var freeVars map[string]string

--- a/internal/provider/resource_service_convert_test.go
+++ b/internal/provider/resource_service_convert_test.go
@@ -1,0 +1,164 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/dunkin0486/terraform-provider-nagios/internal/client"
+)
+
+func TestServiceFromModel_FullyPopulated(t *testing.T) {
+	ctx := context.Background()
+
+	hostName, _ := types.SetValueFrom(ctx, types.StringType, []string{"web01", "web02"})
+	contacts, _ := types.SetValueFrom(ctx, types.StringType, []string{"nagiosadmin"})
+	notificationOptions, _ := types.SetValueFrom(ctx, types.StringType, []string{"w", "c"})
+	freeVars, _ := types.MapValueFrom(ctx, types.StringType, map[string]string{"_TIER": "web"})
+
+	m := &serviceModel{
+		ServiceName:          types.StringValue("web01-http"),
+		HostName:             hostName,
+		Description:          types.StringValue("HTTP"),
+		CheckCommand:         types.StringValue("check_http"),
+		MaxCheckAttempts:     types.StringValue("3"),
+		CheckInterval:        types.StringValue("5"),
+		RetryInterval:        types.StringValue("1"),
+		CheckPeriod:          types.StringValue("24x7"),
+		NotificationInterval: types.StringValue("30"),
+		NotificationPeriod:   types.StringValue("24x7"),
+		Contacts:             contacts,
+		IsVolatile:           types.BoolValue(false),
+		ActiveChecksEnabled:  types.BoolValue(true),
+		NotificationOptions:  notificationOptions,
+		Register:             types.BoolValue(true),
+		FreeVariables:        freeVars,
+	}
+
+	s, diags := serviceFromModel(ctx, m)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if s.ServiceName != "web01-http" {
+		t.Errorf("ServiceName = %q, want web01-http", s.ServiceName)
+	}
+	if len(s.HostName) != 2 {
+		t.Errorf("HostName = %#v, want 2 elements", s.HostName)
+	}
+	if s.IsVolatile != "0" {
+		t.Errorf("IsVolatile = %q, want 0", s.IsVolatile)
+	}
+	if s.ActiveChecksEnabled != "1" {
+		t.Errorf("ActiveChecksEnabled = %q, want 1", s.ActiveChecksEnabled)
+	}
+	if len(s.NotificationOptions) != 2 {
+		t.Errorf("NotificationOptions = %#v, want 2 elements", s.NotificationOptions)
+	}
+	if s.FreeVariables["_TIER"] != "web" {
+		t.Errorf("FreeVariables = %#v, want map[_TIER:web]", s.FreeVariables)
+	}
+}
+
+func TestServiceFromModel_UnsetOptionalBool(t *testing.T) {
+	ctx := context.Background()
+
+	hostName, _ := types.SetValueFrom(ctx, types.StringType, []string{"web01"})
+	m := &serviceModel{
+		ServiceName:          types.StringValue("web01-http"),
+		HostName:             hostName,
+		Description:          types.StringValue("HTTP"),
+		CheckCommand:         types.StringValue("check_http"),
+		MaxCheckAttempts:     types.StringValue("3"),
+		CheckInterval:        types.StringValue("5"),
+		RetryInterval:        types.StringValue("1"),
+		CheckPeriod:          types.StringValue("24x7"),
+		NotificationInterval: types.StringValue("30"),
+		NotificationPeriod:   types.StringValue("24x7"),
+		IsVolatile:           types.BoolNull(),
+	}
+
+	s, diags := serviceFromModel(ctx, m)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if s.IsVolatile != "" {
+		t.Errorf("IsVolatile = %q, want \"\" (omitted) for an unset optional bool", s.IsVolatile)
+	}
+}
+
+func TestModelFromService_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	s := &client.Service{
+		ServiceName:          "web01-http",
+		HostName:             []string{"web01"},
+		Description:          "HTTP",
+		CheckCommand:         "check_http",
+		MaxCheckAttempts:     "3",
+		CheckInterval:        "5",
+		RetryInterval:        "1",
+		CheckPeriod:          "24x7",
+		NotificationInterval: "30",
+		NotificationPeriod:   "24x7",
+		IsVolatile:           "1",
+		FreeVariables:        map[string]string{"_TIER": "web"},
+	}
+
+	var m serviceModel
+	diags := modelFromService(ctx, &m, s)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if m.ServiceName.ValueString() != "web01-http" {
+		t.Errorf("ServiceName = %q, want web01-http", m.ServiceName.ValueString())
+	}
+	if !m.IsVolatile.ValueBool() {
+		t.Errorf("IsVolatile = %v, want true", m.IsVolatile)
+	}
+
+	var freeVars map[string]string
+	diags = m.FreeVariables.ElementsAs(ctx, &freeVars, false)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics reading FreeVariables: %v", diags)
+	}
+	if freeVars["_TIER"] != "web" {
+		t.Errorf("FreeVariables = %#v, want map[_TIER:web]", freeVars)
+	}
+}
+
+func TestModelFromService_EmptyOptionalsBecomeNull(t *testing.T) {
+	ctx := context.Background()
+
+	s := &client.Service{
+		ServiceName:          "web01-http",
+		HostName:             []string{"web01"},
+		Description:          "HTTP",
+		CheckCommand:         "check_http",
+		MaxCheckAttempts:     "3",
+		CheckInterval:        "5",
+		RetryInterval:        "1",
+		CheckPeriod:          "24x7",
+		NotificationInterval: "30",
+		NotificationPeriod:   "24x7",
+	}
+
+	var m serviceModel
+	diags := modelFromService(ctx, &m, s)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if !m.DisplayName.IsNull() {
+		t.Errorf("DisplayName = %#v, want null for an empty API response value", m.DisplayName)
+	}
+	if !m.IsVolatile.IsNull() {
+		t.Errorf("IsVolatile = %#v, want null for an empty API response value", m.IsVolatile)
+	}
+	if !m.FreeVariables.IsNull() {
+		t.Errorf("FreeVariables = %#v, want null for an empty API response value", m.FreeVariables)
+	}
+}

--- a/internal/provider/resource_servicegroup_convert_test.go
+++ b/internal/provider/resource_servicegroup_convert_test.go
@@ -1,0 +1,64 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/dunkin0486/terraform-provider-nagios/internal/client"
+)
+
+func TestServicegroupFromModel(t *testing.T) {
+	ctx := context.Background()
+
+	// Nagios expects members as a flat, alternating (host, service) list -
+	// see resource_servicegroup.go's schema description.
+	members, _ := types.SetValueFrom(ctx, types.StringType, []string{"web01", "HTTP"})
+	m := &servicegroupModel{
+		Name:    types.StringValue("http-checks"),
+		Alias:   types.StringValue("HTTP Checks"),
+		Members: members,
+	}
+
+	sg, diags := servicegroupFromModel(ctx, m)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if sg.Name != "http-checks" {
+		t.Errorf("Name = %q, want http-checks", sg.Name)
+	}
+	if len(sg.Members) != 2 {
+		t.Errorf("Members = %#v, want 2 elements", sg.Members)
+	}
+}
+
+func TestModelFromServicegroup(t *testing.T) {
+	ctx := context.Background()
+
+	sg := &client.Servicegroup{
+		Name:    "http-checks",
+		Alias:   "HTTP Checks",
+		Members: []string{"web01", "HTTP"},
+	}
+
+	var m servicegroupModel
+	diags := modelFromServicegroup(ctx, &m, sg)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if m.Name.ValueString() != "http-checks" {
+		t.Errorf("Name = %q, want http-checks", m.Name.ValueString())
+	}
+
+	var members []string
+	diags = m.Members.ElementsAs(ctx, &members, false)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics reading Members: %v", diags)
+	}
+	if len(members) != 2 {
+		t.Errorf("Members = %#v, want 2 elements", members)
+	}
+}

--- a/internal/provider/resource_servicegroup_convert_test.go
+++ b/internal/provider/resource_servicegroup_convert_test.go
@@ -12,8 +12,6 @@ import (
 func TestServicegroupFromModel(t *testing.T) {
 	ctx := context.Background()
 
-	// Nagios expects members as a flat, alternating (host, service) list -
-	// see resource_servicegroup.go's schema description.
 	members, _ := types.SetValueFrom(ctx, types.StringType, []string{"web01", "HTTP"})
 	m := &servicegroupModel{
 		Name:    types.StringValue("http-checks"),


### PR DESCRIPTION
## Summary

Phase 1 of #88: `internal/provider` had zero unit tests - only `TF_ACC` acceptance tests, which CI never runs. These are pure data-transformation functions (no HTTP, no framework server, no Docker), so they're cheap to test directly:

- `convert.go`'s helpers (`setToStrings`/`stringsToSet`, `mapToStrings`/`stringsMapToMap`, `stringOrNull`, `optionalBoolToNagios`/`nagiosToOptionalBool`)
- Every resource's `<type>FromModel`/`modelFrom<Type>` converters (host, service, hostgroup, servicegroup, contact, contactgroup, authserver)

`optionalBoolToNagios`/`nagiosToOptionalBool` get the most direct coverage - this is literally the fix for the historically-shipped null-vs-false bool bug (see CLAUDE.md), and previously had no unit tests at all; only the acceptance suite could have caught a regression here, and CI never runs it.

While writing the contactgroup tests, found `contactgroup_members` is already fully implemented (has been since PR #87) - not actually a gap as originally listed in #106. Corrected that issue and the local research notes separately; no code change needed here.

## Test plan

- [x] `internal/provider` unit coverage: 0% -> 28.9% (`go test ./internal/provider/... -cover`)
- [x] Acceptance tests continue to skip cleanly without `TF_ACC` (verified) - purely additive, no existing test behavior changed
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] `golangci-lint run ./...` (v2.12.2, matches CI) - 0 issues
- [x] `go test ./internal/client/...` - pass

Refs #88

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>