### PR TITLE
test: httptest-backed client and resource unit tests (#88 phase 2)

### DIFF
--- a/internal/client/authserver_test.go
+++ b/internal/client/authserver_test.go
@@ -1,0 +1,157 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestNewAuthServer_MergesCreateResponseIntoCallerStruct is CLAUDE.md quirk 6:
+// the create response body is only {"success":"...", "server_id":"..."} -
+// not the full object - so NewAuthServer unmarshals that response directly
+// into the caller's already-populated *AuthServer, leaving the other fields
+// (set from the caller's input) untouched while filling in ServerID/ID.
+func TestNewAuthServer_MergesCreateResponseIntoCallerStruct(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/system/authserver":
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("failed to parse create form body: %v", err)
+			}
+			if got := r.PostFormValue("conn_method"); got != "ldap" {
+				t.Errorf("conn_method = %q, want %q", got, "ldap")
+			}
+			_, _ = w.Write([]byte(`{"success":"Authentication server successfully added","server_id":"7"}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/system/applyconfig":
+			_, _ = w.Write([]byte(`{"success":"ok"}`))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "TOKEN")
+	a := &AuthServer{Enabled: "1", ConnectionMethod: "ldap", LDAPHost: "ldap.example.com"}
+	if err := c.NewAuthServer(context.Background(), a); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if a.ServerID != "7" || a.ID != "7" {
+		t.Errorf("ServerID/ID = %q/%q, want both %q", a.ServerID, a.ID, "7")
+	}
+	if a.LDAPHost != "ldap.example.com" {
+		t.Errorf("expected caller-supplied LDAPHost to survive the merge, got %q", a.LDAPHost)
+	}
+}
+
+// TestGetAuthServer_EnvelopeResponseReconcilesID confirms GetAuthServer
+// unwraps the {"records", "authservers"} envelope every other object type
+// doesn't use, and reconciles ServerID <- ID after a GET (the GET response's
+// own field is "id", not "server_id" - see the AuthServer doc comment).
+func TestGetAuthServer_EnvelopeResponseReconcilesID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("server_id"); got != "7" {
+			t.Errorf("expected server_id=7 in query, got %q", got)
+		}
+		_, _ = w.Write([]byte(`{"records":1,"authservers":[{"id":"7","enabled":"1","conn_method":"ldap"}]}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "TOKEN")
+	got, err := c.GetAuthServer(context.Background(), "7")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected a non-nil auth server, got nil")
+	}
+	if got.ServerID != "7" {
+		t.Errorf("ServerID = %q, want %q (reconciled from id)", got.ServerID, "7")
+	}
+}
+
+// TestGetAuthServer_NotFound confirms a zero-records envelope comes back as
+// (nil, nil), matching every other GetX's not-found contract despite the
+// different response shape.
+func TestGetAuthServer_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"records":0,"authservers":[]}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "TOKEN")
+	got, err := c.GetAuthServer(context.Background(), "missing")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil auth server for a zero-records envelope, got %+v", got)
+	}
+}
+
+// TestUpdateAuthServer_DoesNotFallBackOnUnknownEndpoint is CLAUDE.md quirk 7:
+// authserver has no real update route at all - PUT always returns "Unknown
+// API endpoint.", not "Does the authentication server exist?" - so the
+// existsErrorFor fallback other UpdateX methods use never matches here, and
+// the raw error must propagate to the caller rather than triggering a
+// surprise create.
+func TestUpdateAuthServer_DoesNotFallBackOnUnknownEndpoint(t *testing.T) {
+	var sawCreate bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut:
+			_, _ = w.Write([]byte(`{"error":"Unknown API endpoint."}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/system/authserver":
+			sawCreate = true
+			_, _ = w.Write([]byte(`{"success":"ok","server_id":"9"}`))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "TOKEN")
+	a := &AuthServer{ID: "7", Enabled: "0", ConnectionMethod: "ldap"}
+	err := c.UpdateAuthServer(context.Background(), a, "7")
+	if err == nil {
+		t.Fatal("expected the raw \"Unknown API endpoint.\" error to propagate, got nil")
+	}
+	if err.Error() != "Unknown API endpoint." {
+		t.Errorf("got error %q, want %q", err.Error(), "Unknown API endpoint.")
+	}
+	if sawCreate {
+		t.Error("expected no fallback create request, but one was made")
+	}
+}
+
+// TestDeleteAuthServer_UsesPathSegment is CLAUDE.md quirk 5: authserver's
+// DELETE uses a "/{id}" path segment, unlike every other object type's
+// query-param-only style.
+func TestDeleteAuthServer_UsesPathSegment(t *testing.T) {
+	var sawApplyConfig bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodDelete:
+			if r.URL.Path != "/api/v1/system/authserver/7" {
+				t.Errorf("DELETE path = %q, want %q", r.URL.Path, "/api/v1/system/authserver/7")
+			}
+			_, _ = w.Write([]byte(`{"success":"Authentication server successfully deleted"}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/system/applyconfig":
+			sawApplyConfig = true
+			_, _ = w.Write([]byte(`{"success":"ok"}`))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "TOKEN")
+	if err := c.DeleteAuthServer(context.Background(), "7"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !sawApplyConfig {
+		t.Error("expected an applyconfig request after delete, got none")
+	}
+}

--- a/internal/client/host_test.go
+++ b/internal/client/host_test.go
@@ -1,0 +1,224 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestNewHost_PostsFormEncodedParams verifies NewHost sends the host's fields
+// as a form-urlencoded POST body (not query params) and follows up with the
+// applyconfig call every mutating method requires.
+func TestNewHost_PostsFormEncodedParams(t *testing.T) {
+	var sawCreate, sawApplyConfig bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/config/host":
+			sawCreate = true
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("failed to parse create form body: %v", err)
+			}
+			if got := r.PostFormValue("host_name"); got != "myhost" {
+				t.Errorf("host_name = %q, want %q", got, "myhost")
+			}
+			if got := r.PostFormValue("address"); got != "127.0.0.1" {
+				t.Errorf("address = %q, want %q", got, "127.0.0.1")
+			}
+			if r.URL.Query().Get("force") != "1" {
+				t.Errorf("expected force=1 on create, got query %q", r.URL.RawQuery)
+			}
+			_, _ = w.Write([]byte(`{"success":"Host successfully added"}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/system/applyconfig":
+			sawApplyConfig = true
+			_, _ = w.Write([]byte(`{"success":"ok"}`))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "TOKEN")
+	err := c.NewHost(context.Background(), &Host{HostName: "myhost", Address: "127.0.0.1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !sawCreate {
+		t.Error("expected a create request, got none")
+	}
+	if !sawApplyConfig {
+		t.Error("expected an applyconfig request after create, got none")
+	}
+}
+
+// TestGetHost_Found confirms a successful GET both unmarshals the host and
+// extracts free variables from the dynamic top-level "_"-prefixed keys
+// (see CLAUDE.md quirk 8), not from a nested "free_variables" field.
+func TestGetHost_Found(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("host_name") != "myhost" {
+			t.Errorf("expected host_name=myhost in query, got %q", r.URL.RawQuery)
+		}
+		_, _ = w.Write([]byte(`[{"host_name":"myhost","address":"127.0.0.1","_SNMPCOMMUNITY":"public"}]`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "TOKEN")
+	got, err := c.GetHost(context.Background(), "myhost")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected a non-nil host, got nil")
+	}
+	if got.HostName != "myhost" || got.Address != "127.0.0.1" {
+		t.Errorf("got %+v, want host_name=myhost address=127.0.0.1", got)
+	}
+	if got.FreeVariables["_SNMPCOMMUNITY"] != "public" {
+		t.Errorf("FreeVariables = %v, want _SNMPCOMMUNITY=public", got.FreeVariables)
+	}
+}
+
+// TestGetHost_NotFound is the exact contract CLAUDE.md documents as a
+// previously-shipped real bug: an empty result set must come back as
+// (nil, nil), never a non-nil empty struct, or Terraform's state-clearing
+// logic silently breaks.
+func TestGetHost_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "TOKEN")
+	got, err := c.GetHost(context.Background(), "missing")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil host for an empty result set, got %+v", got)
+	}
+}
+
+// TestUpdateHost_Success confirms a successful PUT addresses the *old* name
+// as a path segment (CLAUDE.md quirk 3) and still applies config.
+func TestUpdateHost_Success(t *testing.T) {
+	var sawApplyConfig bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut:
+			if r.URL.Path != "/api/v1/config/host/oldname" {
+				t.Errorf("expected PUT path segment to be the old name, got %q", r.URL.Path)
+			}
+			if got := r.URL.Query().Get("host_name"); got != "newname" {
+				t.Errorf("expected new name in query params, got %q", got)
+			}
+			_, _ = w.Write([]byte(`{"success":"Host successfully updated"}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/system/applyconfig":
+			sawApplyConfig = true
+			_, _ = w.Write([]byte(`{"success":"ok"}`))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "TOKEN")
+	err := c.UpdateHost(context.Background(), &Host{HostName: "newname", Address: "127.0.0.1"}, "oldname")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !sawApplyConfig {
+		t.Error("expected an applyconfig request after a successful update, got none")
+	}
+}
+
+// TestUpdateHost_FallsBackToNewHostOnDoesNotExist exercises the
+// existsErrorFor fallback (CLAUDE.md quirk 11): when Nagios reports the old
+// name no longer exists (e.g. manually deleted out-of-band, or already
+// renamed), UpdateHost falls back to creating the host fresh via NewHost
+// rather than surfacing the error.
+func TestUpdateHost_FallsBackToNewHostOnDoesNotExist(t *testing.T) {
+	var sawCreate bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut:
+			_, _ = w.Write([]byte(`{"error":"Does the host exist?"}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/config/host":
+			sawCreate = true
+			_, _ = w.Write([]byte(`{"success":"Host successfully added"}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/system/applyconfig":
+			_, _ = w.Write([]byte(`{"success":"ok"}`))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "TOKEN")
+	err := c.UpdateHost(context.Background(), &Host{HostName: "newname", Address: "127.0.0.1"}, "goneaway")
+	if err != nil {
+		t.Fatalf("expected the fallback to NewHost to succeed, got error: %v", err)
+	}
+	if !sawCreate {
+		t.Error("expected UpdateHost to fall back to a create request, got none")
+	}
+}
+
+// TestUpdateHost_PropagatesOtherErrors confirms an unrelated PUT failure is
+// surfaced as-is, not silently swallowed into a fallback create.
+func TestUpdateHost_PropagatesOtherErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			_, _ = w.Write([]byte(`{"error":"Some other failure"}`))
+			return
+		}
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "TOKEN")
+	err := c.UpdateHost(context.Background(), &Host{HostName: "newname", Address: "127.0.0.1"}, "oldname")
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if err.Error() != "Some other failure" {
+		t.Errorf("got error %q, want %q", err.Error(), "Some other failure")
+	}
+}
+
+// TestDeleteHost_AppliesConfig confirms DeleteHost issues a DELETE and, per
+// CLAUDE.md quirk 2, still follows up with an applyconfig call.
+func TestDeleteHost_AppliesConfig(t *testing.T) {
+	var sawDelete, sawApplyConfig bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodDelete:
+			sawDelete = true
+			if got := r.URL.Query().Get("host_name"); got != "myhost" {
+				t.Errorf("expected host_name=myhost in query, got %q", got)
+			}
+			_, _ = w.Write([]byte(`{"success":"Host successfully deleted"}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/system/applyconfig":
+			sawApplyConfig = true
+			_, _ = w.Write([]byte(`{"success":"ok"}`))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "TOKEN")
+	if err := c.DeleteHost(context.Background(), "myhost"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !sawDelete {
+		t.Error("expected a delete request, got none")
+	}
+	if !sawApplyConfig {
+		t.Error("expected an applyconfig request after delete, got none")
+	}
+}

--- a/internal/client/service_test.go
+++ b/internal/client/service_test.go
@@ -1,0 +1,157 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestGetService_KeysOffConfigNameAndReturnsFreeVariables confirms GetService
+// filters by config_name (not description) and extracts free variables the
+// same way GetHost does.
+func TestGetService_KeysOffConfigNameAndReturnsFreeVariables(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("config_name"); got != "my_service" {
+			t.Errorf("expected config_name=my_service in query, got %q", got)
+		}
+		_, _ = w.Write([]byte(`[{"config_name":"my_service","service_description":"CPU Load","_CUSTOM":"x"}]`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "TOKEN")
+	got, err := c.GetService(context.Background(), "my_service")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected a non-nil service, got nil")
+	}
+	if got.Description != "CPU Load" {
+		t.Errorf("Description = %q, want %q", got.Description, "CPU Load")
+	}
+	if got.FreeVariables["_CUSTOM"] != "x" {
+		t.Errorf("FreeVariables = %v, want _CUSTOM=x", got.FreeVariables)
+	}
+}
+
+func TestGetService_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "TOKEN")
+	got, err := c.GetService(context.Background(), "missing")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil service for an empty result set, got %+v", got)
+	}
+}
+
+// TestUpdateService_PUTAddressesOldNameAndOldDescription confirms the PUT
+// path segment is built from (oldServiceName, oldDescription) - services are
+// addressed by that compound key on GET/PUT, distinct from DELETE's
+// (host_name, description) key (CLAUDE.md quirk 4).
+func TestUpdateService_PUTAddressesOldNameAndOldDescription(t *testing.T) {
+	var sawApplyConfig bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut:
+			want := "/api/v1/config/service/old_svc/old description"
+			if r.URL.Path != want {
+				t.Errorf("PUT path = %q, want %q", r.URL.Path, want)
+			}
+			_, _ = w.Write([]byte(`{"success":"Service successfully updated"}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/system/applyconfig":
+			sawApplyConfig = true
+			_, _ = w.Write([]byte(`{"success":"ok"}`))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "TOKEN")
+	s := &Service{ServiceName: "new_svc", Description: "new description", HostName: []string{"host1"}}
+	if err := c.UpdateService(context.Background(), s, "old_svc", "old description"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !sawApplyConfig {
+		t.Error("expected an applyconfig request after a successful update, got none")
+	}
+}
+
+// TestUpdateService_FallsBackToNewServiceOnDoesNotExist mirrors the host
+// existsErrorFor fallback test, for the "service" object type string.
+func TestUpdateService_FallsBackToNewServiceOnDoesNotExist(t *testing.T) {
+	var sawCreate bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut:
+			_, _ = w.Write([]byte(`{"error":"Does the service exist?"}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/config/service":
+			sawCreate = true
+			_, _ = w.Write([]byte(`{"success":"Service successfully added"}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/system/applyconfig":
+			_, _ = w.Write([]byte(`{"success":"ok"}`))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "TOKEN")
+	s := &Service{ServiceName: "new_svc", Description: "new description", HostName: []string{"host1"}}
+	if err := c.UpdateService(context.Background(), s, "gone_svc", "gone description"); err != nil {
+		t.Fatalf("expected the fallback to NewService to succeed, got error: %v", err)
+	}
+	if !sawCreate {
+		t.Error("expected UpdateService to fall back to a create request, got none")
+	}
+}
+
+// TestDeleteService_JoinsMultipleHostsAndEscapesSpaces is the real gap
+// #88 called out: DeleteService keys off (host_name, description), where
+// host_name is the full host set comma-joined into one value (CLAUDE.md
+// quirk 4), and no existing test ever exercised more than one host or a
+// description containing a space.
+func TestDeleteService_JoinsMultipleHostsAndEscapesSpaces(t *testing.T) {
+	var requestURI string
+	var sawApplyConfig bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodDelete:
+			requestURI = r.RequestURI
+			if got := r.URL.Query().Get("host_name"); got != "host1,host2,host3" {
+				t.Errorf("host_name = %q, want %q", got, "host1,host2,host3")
+			}
+			if got := r.URL.Query().Get("service_description"); got != "CPU Load" {
+				t.Errorf("service_description = %q, want %q", got, "CPU Load")
+			}
+			_, _ = w.Write([]byte(`{"success":"Service successfully deleted"}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/system/applyconfig":
+			sawApplyConfig = true
+			_, _ = w.Write([]byte(`{"success":"ok"}`))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "TOKEN")
+	if err := c.DeleteService(context.Background(), "host1,host2,host3", "CPU Load"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !sawApplyConfig {
+		t.Error("expected an applyconfig request after delete, got none")
+	}
+	if requestURI == "" {
+		t.Fatal("delete request never reached the server handler")
+	}
+}

--- a/internal/provider/resource_host_unit_test.go
+++ b/internal/provider/resource_host_unit_test.go
@@ -1,0 +1,199 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// multiValueHostFields lists the nagios_host fields that arrive over the
+// wire as a single CSV-joined form/query value (see setURLParams'
+// mapArrayToString) but must round-trip back out of GET as a JSON array,
+// matching the real API's response shape.
+var multiValueHostFields = map[string]bool{
+	"contacts":               true,
+	"templates":              true,
+	"use":                    true,
+	"contact_groups":         true,
+	"parents":                true,
+	"flap_detection_options": true,
+}
+
+// newMockNagiosHostServer stands in for a real Nagios XI instance, backing
+// only the "host" object type and applyconfig - enough to drive
+// nagios_host's full Create/Read/Update/Delete lifecycle through
+// resource.UnitTest without TF_ACC or Docker (see CLAUDE.md's description of
+// #88's phase 2). It returns the server and a function to check whether a
+// host by that name currently "exists" in the mock backend, so a test can
+// confirm Delete actually ran.
+func newMockNagiosHostServer(t *testing.T) (*httptest.Server, func(name string) bool) {
+	t.Helper()
+
+	var mu sync.Mutex
+	hosts := map[string]url.Values{}
+
+	writeSuccess := func(w http.ResponseWriter) {
+		_, _ = w.Write([]byte(`{"success":"ok"}`))
+	}
+
+	toJSONObject := func(v url.Values) map[string]any {
+		obj := map[string]any{}
+		for k, vals := range v {
+			if k == "apikey" || k == "pretty" || k == "force" || len(vals) == 0 {
+				continue
+			}
+			if multiValueHostFields[k] {
+				if vals[0] == "" {
+					obj[k] = []string{}
+				} else {
+					obj[k] = strings.Split(vals[0], ",")
+				}
+				continue
+			}
+			obj[k] = vals[0]
+		}
+		return obj
+	}
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("POST /api/v1/system/applyconfig", func(w http.ResponseWriter, r *http.Request) {
+		writeSuccess(w)
+	})
+
+	mux.HandleFunc("POST /api/v1/config/host", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		mu.Lock()
+		hosts[r.PostForm.Get("host_name")] = cloneURLValues(r.PostForm)
+		mu.Unlock()
+		writeSuccess(w)
+	})
+
+	mux.HandleFunc("GET /api/v1/config/host", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		rec, ok := hosts[r.URL.Query().Get("host_name")]
+		mu.Unlock()
+		if !ok {
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
+		body, err := json.Marshal([]map[string]any{toJSONObject(rec)})
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write(body)
+	})
+
+	mux.HandleFunc("PUT /api/v1/config/host/{oldName}", func(w http.ResponseWriter, r *http.Request) {
+		oldName := r.PathValue("oldName")
+
+		mu.Lock()
+		defer mu.Unlock()
+		if _, ok := hosts[oldName]; !ok {
+			_, _ = w.Write([]byte(`{"error":"Does the host exist?"}`))
+			return
+		}
+		delete(hosts, oldName)
+		hosts[r.URL.Query().Get("host_name")] = cloneURLValues(r.URL.Query())
+		writeSuccess(w)
+	})
+
+	mux.HandleFunc("DELETE /api/v1/config/host", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		delete(hosts, r.URL.Query().Get("host_name"))
+		mu.Unlock()
+		writeSuccess(w)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	exists := func(name string) bool {
+		mu.Lock()
+		defer mu.Unlock()
+		_, ok := hosts[name]
+		return ok
+	}
+	return srv, exists
+}
+
+func cloneURLValues(v url.Values) url.Values {
+	out := make(url.Values, len(v))
+	for k, vals := range v {
+		cp := make([]string, len(vals))
+		copy(cp, vals)
+		out[k] = cp
+	}
+	return out
+}
+
+func testUnitHostConfig(nagiosURL, address string) string {
+	return fmt.Sprintf(`
+provider "nagios" {
+  url   = %[1]q
+  token = "TEST-TOKEN"
+}
+
+resource "nagios_host" "test" {
+  host_name             = "myhost"
+  address               = %[2]q
+  max_check_attempts    = "5"
+  check_period          = "24x7"
+  notification_interval  = "10"
+  notification_period    = "24x7"
+  contacts               = ["nagiosadmin"]
+  alias                  = "myalias"
+}
+`, nagiosURL, address)
+}
+
+// TestUnitHostLifecycle drives nagios_host's full Create/Read/Update/Delete
+// path through the real terraform-plugin-framework server, against a mock
+// Nagios backend instead of a live instance or TF_ACC/Docker - closing the
+// #88 gap that this path was previously only ever exercised by the
+// TF_ACC-gated acceptance suite, which CI never runs.
+func TestUnitHostLifecycle(t *testing.T) {
+	srv, hostExists := newMockNagiosHostServer(t)
+	rName := "nagios_host.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testUnitHostConfig(srv.URL, "127.0.0.1"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "host_name", "myhost"),
+					resource.TestCheckResourceAttr(rName, "address", "127.0.0.1"),
+					resource.TestCheckResourceAttr(rName, "alias", "myalias"),
+					resource.TestCheckResourceAttr(rName, "register", "true"),
+				),
+			},
+			{
+				// Changes a non-identifying attribute in place - the exact
+				// gap #88 called out: every acceptance UpdateName test only
+				// ever renames, never exercises a plain in-place attribute
+				// change through UpdateHost.
+				Config: testUnitHostConfig(srv.URL, "127.0.0.2"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "host_name", "myhost"),
+					resource.TestCheckResourceAttr(rName, "address", "127.0.0.2"),
+				),
+			},
+		},
+	})
+
+	if hostExists("myhost") {
+		t.Error("expected the host to be deleted from the mock backend after the test, but it still exists")
+	}
+}


### PR DESCRIPTION
## Summary

Phase 2 of #88: fast, dependency-free tests for `internal/client`'s CRUD methods and a full resource lifecycle test, backed by `httptest.Server` instead of a live Nagios XI instance. None of this requires `TF_ACC` or Docker, so it runs in CI on every PR (unlike the existing acceptance suite in `internal/provider/*_test.go`).

- `internal/client/host_test.go` - full CRUD lifecycle for the reference object type: create (form-encoded POST + applyconfig), get (found + the `(nil, nil)`-on-empty-array not-found contract - CLAUDE.md's headline bug fix), update (success + the `existsErrorFor` rename-after-manual-delete fallback to create + unrelated-error passthrough), delete.
- `internal/client/service_test.go` - the real compound-key inconsistency: GET/PUT key off `(config_name, description)` while DELETE keys off `(host_name, description)` with a comma-joined multi-host value; also verifies a space-containing description reaches the wire `%20`-escaped through `DeleteService`'s manual query concatenation.
- `internal/client/authserver_test.go` - the create-response-merges-into-caller's-struct behavior (create only returns `{"success","server_id"}`, not the full object), the `id`/`server_id` field reconciliation on GET's envelope-wrapped response, and confirmation that `UpdateAuthServer` does *not* fall back to create on Nagios's real `"Unknown API endpoint."` response (it has no update route at all).
- `internal/provider/resource_host_unit_test.go` - a small in-memory mock Nagios server plus a `resource.UnitTest` that drives `nagios_host` through real Create → in-place (non-renaming) Update → Delete via the actual `terraform-plugin-framework` server. Closes the specific gap #88 flagged: every existing acceptance `UpdateName` test only ever renames, never exercises a plain attribute change through `Update`.

Deliberately scoped out: `contact`/`contactgroup`/`hostgroup`/`servicegroup` are structurally identical to `host` (no per-type quirks), and only `nagios_host` got a resource.UnitTest - filed #124 to extend the same pattern to the remaining client object types later.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` clean
- [x] `golangci-lint run ./...` - 0 issues
- [x] `go test ./internal/...` - all new tests pass, no existing tests regressed