### PR TITLE
ci: wire up Codecov coverage reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,5 +37,11 @@ jobs:
         with:
           terraform_wrapper: false
       - run: go build ./...
-      - run: go test -v ./internal/...
+      - run: go test -v -coverprofile=coverage.out -covermode=atomic ./internal/...
       - run: terraform fmt -check -recursive examples/
+      - uses: codecov/codecov-action@v5
+        with:
+          files: coverage.out
+          flags: unit
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Terraform provider for Nagios XI
 
 [![test](https://github.com/dunkin0486/terraform-provider-nagios/actions/workflows/test.yml/badge.svg)](https://github.com/dunkin0486/terraform-provider-nagios/actions/workflows/test.yml)
+[![codecov](https://codecov.io/gh/dunkin0486/terraform-provider-nagios/branch/main/graph/badge.svg)](https://codecov.io/gh/dunkin0486/terraform-provider-nagios)
 [![Terraform Registry](https://img.shields.io/badge/terraform--registry-dunkin0486%2Fnagios-844FBA?logo=terraform)](https://registry.terraform.io/providers/dunkin0486/nagios/latest)
 
 ## Supported Nagios XI versions

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,17 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "reach,diff,flags,files"
+
+flags:
+  unit:
+    paths:
+      - internal/
+    carryforward: false


### PR DESCRIPTION
## Summary

Item 3 of #88: coverage tooling. Wires up Codecov for repo-wide/PR coverage reporting now that phases 1 (#121) and 2 (#125) established unit test coverage in `internal/client` and `internal/provider`.

- `.github/workflows/test.yml`: `test` job now runs `go test -coverprofile=coverage.out -covermode=atomic ./internal/...` and uploads via `codecov/codecov-action@v5` under a `unit` flag. `fail_ci_if_error: false` so a Codecov outage never breaks CI.
- `codecov.yml`: project and patch status checks are `informational: true` — reports/annotates without blocking merges, since `internal/provider` is only ~39% covered today and a hard gate would immediately block most PRs. Only a `unit` flag is defined; an `acceptance` flag is deferred until/unless the `TF_ACC` suite ever runs in CI (explicitly a non-goal of #88).
- `README.md`: added the Codecov badge.

Repo is linked on codecov.io and `CODECOV_TOKEN` is already set as a repo secret.

## Test plan

- [x] `go test -coverprofile=coverage.out -covermode=atomic ./internal/...` run locally — `internal/client` 57.2%, `internal/provider` 39.3%, no failures
- [x] Confirm CI run on this PR uploads successfully to Codecov and posts a PR comment

Refs #88

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>